### PR TITLE
include <queue> to use std::priority_queue

### DIFF
--- a/example/general_cnn_example_in_cpp.cpp
+++ b/example/general_cnn_example_in_cpp.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <numeric>
+#include <queue>
 #include <string>
 #include <vector>
 

--- a/example/vgg16_example_in_cpp.cpp
+++ b/example/vgg16_example_in_cpp.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <numeric>
+#include <queue>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This fixes following errors generated by `g++-7`.

```
/home/travis/build/msakai/menoh/example/vgg16_example_in_cpp.cpp: In function ‘auto extract_top_k_index_list(InIter, InIter, typename std::iterator_traits<_Iter>::difference_type)’:
menoh/example/vgg16_example_in_cpp.cpp:48:10: error: ‘priority_queue’ is not a member of ‘std’
     std::priority_queue<
          ^~~~~~~~~~~~~~
menoh/example/vgg16_example_in_cpp.cpp:49:74: error: expected primary-expression before ‘>’ token
       std::pair<typename std::iterator_traits<InIter>::value_type, diff_t>>
                                                                          ^~
menoh/example/vgg16_example_in_cpp.cpp:50:7: error: ‘q’ was not declared in this scope
       q;
       ^
```