### PR TITLE
include <fstream> to use std::ifstream

### DIFF
--- a/example/general_cnn_example_in_cpp.cpp
+++ b/example/general_cnn_example_in_cpp.cpp
@@ -2,6 +2,7 @@
 #include <Windows.h>
 #endif
 
+#include <fstream>
 #include <iostream>
 #include <numeric>
 #include <queue>

--- a/example/vgg16_example_in_cpp.cpp
+++ b/example/vgg16_example_in_cpp.cpp
@@ -2,6 +2,7 @@
 #include <Windows.h>
 #endif
 
+#include <fstream>
 #include <iostream>
 #include <numeric>
 #include <queue>


### PR DESCRIPTION
This fixes following error generated by `g++-7`.

```
menoh/example/vgg16_example_in_cpp.cpp: In function ‘auto load_category_list(const string&)’:
menoh/example/vgg16_example_in_cpp.cpp:63:40: error: variable ‘std::ifstream ifs’ has initializer but incomplete type
     std::ifstream ifs(synset_words_path);
                                        ^
```
