### PR TITLE
use sys.executable as python interpreter name instead of hard-coded "python"

### DIFF
--- a/gen_benchmark_data.py
+++ b/gen_benchmark_data.py
@@ -10,7 +10,7 @@ def call( cmd ):
     ret = p.wait()
     print('')
 
-pyexe = 'python'
+pyexe = sys.executable
 
 # Generate input data
 call(pyexe + ' test/script/make_random_data.py 1 3 224 224 --output data/random_input_1_3_224_224.txt')

--- a/gen_test_data.py
+++ b/gen_test_data.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 
 
@@ -11,7 +12,7 @@ def call(cmd):
     print('')
 
 
-pyexe = 'python'
+pyexe = sys.executable
 
 # Generate input data
 call(


### PR DESCRIPTION
This would be useful when `gen_benchmark_data.py` or `gen_test_data.py` is invoked using `python2` or `python3` but `python` refers to different version.