### PR TITLE
Travis-CI configuration 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
     - cd build
     - sh ../.travis/run_cmake.sh
     - make
-    - ./test/menoh_test
+    # - ./test/menoh_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+dist: trusty
+sudo: false
+language: cpp
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+        packages:
+            - gcc-7
+            - g++-7
+            - cmake-data
+            - cmake
+            - libopencv-dev
+            - python
+cache:
+    directories:
+        - $HOME/protoc
+        - $HOME/mkl-dnn
+install:
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-7" CC="gcc-7"; fi
+    - sh .travis/install_protoc.sh
+    - sh .travis/install_mkldnn.sh
+    - mkdir -p data
+    - pip install --user chainer
+    - python retrieve_data.py
+    - python gen_test_data.py
+before_script:
+    - ls -R $HOME/protoc
+    - ls -R $HOME/mkl-dnn
+script:
+    - mkdir build
+    - cd build
+    - sh ../.travis/run_cmake.sh
+    - make
+    - ./test/menoh_test

--- a/.travis/autogen.patch
+++ b/.travis/autogen.patch
@@ -1,0 +1,14 @@
+--- protobuf-2.6.1/autogen.sh	2014-10-21 09:06:06.000000000 +0900
++++ autogen.sh	2017-12-21 23:44:39.675403960 +0900
+@@ -19,8 +19,9 @@
+ # directory is set up as an SVN external.
+ if test ! -e gtest; then
+   echo "Google Test not present.  Fetching gtest-1.5.0 from the web..."
+-  curl http://googletest.googlecode.com/files/gtest-1.5.0.tar.bz2 | tar jx
+-  mv gtest-1.5.0 gtest
++  wget https://github.com/google/googletest/archive/release-1.5.0.tar.gz
++  tar xvf release-1.5.0.tar.gz
++  mv googletest-release-1.5.0 gtest
+ fi
+ 
+ set -ex

--- a/.travis/install_mkldnn.sh
+++ b/.travis/install_mkldnn.sh
@@ -1,0 +1,13 @@
+if [ ! -d "$HOME/mkl-dnn/lib" ]; then
+    git clone https://github.com/intel/mkl-dnn.git
+    cd mkl-dnn
+    git checkout v0.14
+    cd scripts && bash ./prepare_mkl.sh && cd ..
+    sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt
+    sed -i 's/add_subdirectory(tests)//g' CMakeLists.txt
+    mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/mkl-dnn .. && make
+    make install
+    cd ..
+else
+    echo "Using cached directory."
+fi

--- a/.travis/install_protoc.sh
+++ b/.travis/install_protoc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+if [ ! -d "$HOME/protoc/bin" ]; then
+    wget https://github.com/google/protobuf/archive/v2.6.1.tar.gz -O protobuf.tar.gz
+    tar -xzvf protobuf.tar.gz
+    mv protobuf-2.6.1 protobuf
+    cd protobuf
+    patch -u autogen.sh < ../.travis/autogen.patch
+    ./autogen.sh
+    ./configure --prefix=$HOME/protoc
+    make && make install
+    cd ..
+else
+    echo "Using cached directory."
+fi

--- a/.travis/run_cmake.sh
+++ b/.travis/run_cmake.sh
@@ -1,0 +1,9 @@
+cmake \
+    -DENABLE_TEST=ON \
+    -DProtobuf_PROTOC_EXECUTABLE="$HOME/protoc/bin/protoc" \
+    -DProtobuf_INCLUDE_DIR="$HOME/protoc/include" \
+    -DProtobuf_LIBRARY="$HOME/protoc/lib/libprotobuf.so" \
+    -DProtobuf_PROTOC_LIBRARY="$HOME/protoc/lib/libprotoc.so" \
+    -DMKLDNN_INCLUDE_DIR="$HOME/mkl-dnn/include" \
+    -DMKLDNN_LIBRARY="$HOME/mkl-dnn/lib/libmkldnn.so" \
+    ..


### PR DESCRIPTION
This PR adds Travis-CI configuration.

It is based on the one for https://github.com/okdshin/instant/ but I modified a little:
* use Container-based environment instead of sudo-enabled environment,
* specify MKL-DNN version explicitly,
* etc.

Also I disabled `menoh_test` because running it causes segmentation fault on Travis-CI environment. I haven't investigated the cause yet...
https://travis-ci.org/msakai/menoh/builds/394931222