### PR TITLE
fix ./example/vgg16_example to ./example/vgg16_example_in_cpp at READ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ top 5 categories are
 Please give `--help` option for details
 
 ```
-./example/vgg16_example --help
+./example/vgg16_example_in_cpp --help
 ```
 
 


### PR DESCRIPTION
This PR is very tiny.
I fix `./example/vgg16_example` to `./example/vgg_example_in_cpp` at README.md.
I think it would be nice because `./example/vgg16_example_in_cpp` return a help table, but `./example/vgg16_example_in_c` doesn't return it.