### PR TITLE
Using Python 3 instead of Python 2 on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
             - libopencv-dev
             - libprotobuf-dev
             - protobuf-compiler
-            - python
 cache:
     directories:
         - $HOME/mkl-dnn
@@ -23,6 +22,7 @@ install:
     - if [ "$CXX" = "g++" ]; then export CXX="g++-7" CC="gcc-7"; fi
     - sh .travis/install_mkldnn.sh
     - mkdir -p data
+    - pyenv local 3.6
     - pip install --user chainer
     - python retrieve_data.py
     - python gen_test_data.py


### PR DESCRIPTION
This PR make Travis-CI to use Python 3 instead of Python 2.
Let's travel through time to the present age ;-)

Note that we use Travis-CI's built-in pyenv environment, so we do not need to install python3 package using apt.