### PR TITLE
Stop using george-edison55-precise-backports PPA on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
     apt:
         sources:
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
             - sourceline: 'ppa:maarten-fonville/protobuf'
         packages:
             - gcc-7


### PR DESCRIPTION
Since we are using Trusty environment, packages for Precise environment are unnecessary.