### PR TITLE
fix undefined reference errors on mingw

### DIFF
--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -5,7 +5,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+#if (defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
 #define MENOH_API __declspec(dllexport)
 #else
 #define MENOH_API


### PR DESCRIPTION
`onnx_viewer`, `menoh_test` and `vgg16_benchmark` refer to symbols under `menoh_impl` that are not exported from menoh DLL. This causes link error and failure of whole build process, which is nuisance for continuous integration.

As a temporary measure to avoid the problem on `mingw`, this commit disable `__declspec(dllexport)` on mingw. If there are no `__declspec(dllexport)`, gcc builds a DLL that exports all symbols.

cc: @durswd 