### PR TITLE
stop invoking retrieve_data.py on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sh .travis/install_mkldnn.sh; fi
     - mkdir -p data
     - pip install --user chainer
-    - python retrieve_data.py
+    # - python retrieve_data.py
     - python gen_test_data.py
 before_script:
     - ls -R $HOME/mkl-dnn


### PR DESCRIPTION
This stops invoking `retrieve_data.py` on Travis-CI.
Downloaded files are currently not used, and downloading large file every time is not a good thing.