### PR TITLE
Fix segmentation fault in menoh_impl::extract_needed_node_list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ script:
         ..
       fi
     - make
-    # - ./test/menoh_test
+    - ./test/menoh_test

--- a/menoh/graph.cpp
+++ b/menoh/graph.cpp
@@ -36,6 +36,8 @@ namespace menoh_impl {
                             return output_name == required_output_name;
                         });
                   });
+                if (needed_node_iter==node_list.end())
+                    continue;
                 auto is_already_added =
                   std::find(needed_node_list.begin(), needed_node_list.end(),
                             *needed_node_iter) != needed_node_list.end();

--- a/menoh/graph.cpp
+++ b/menoh/graph.cpp
@@ -36,8 +36,7 @@ namespace menoh_impl {
                             return output_name == required_output_name;
                         });
                   });
-                if (needed_node_iter==node_list.end())
-                    continue;
+                if(needed_node_iter == node_list.end()) { continue; }
                 auto is_already_added =
                   std::find(needed_node_list.begin(), needed_node_list.end(),
                             *needed_node_iter) != needed_node_list.end();


### PR DESCRIPTION
This fixes segmentation fault in `menoh_impl::extract_needed_node_list` reported in #9.

`std::find_if(node_list.begin(), node_list.end(), pred)` returns `node_list.end()` when no elements `node_list` satisfy the `pred`, therefore returned iterator must not be dereferenced without proper check.