### PR TITLE
update wrapper information

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ For Windows users, prebuild libraries are available (see [release](https://githu
 See also
 - Chainer model to ONNX : [onnx-chainer](https://github.com/chainer/onnx-chainer)
 - C# wrapper : [menoh-sharp](https://github.com/pfnet-research/menoh-sharp)
+- Go wrapper : [menoh-go](https://github.com/pfnet-research/menoh-go)
+  - (unofficial wrapper [gomenoh](https://github.com/kou-m/gomenoh) by kou-m san has been merged)
 - Haskell wrapper : [menoh-haskell](https://github.com/pfnet-research/menoh-haskell)
-- [Unofficial] Go wrapper by kou-m san : [gomenoh](https://github.com/kou-m/gomenoh)
+- Ruby wrapper : [menoh-ruby](https://github.com/pfnet-research/menoh-ruby)
 - [Unofficial] Rust wrapper by Y-Nak san : [menoh-rs](https://github.com/Y-Nak/menoh-rs)
 - [Unofficial] Rust wrapper by Hakuyume san : [menoh-rs](https://github.com/Hakuyume/menoh-rs)
 


### PR DESCRIPTION
This update links to include Ruby binding and official Go binding.

@disktnk, could you check the the relationship of new go binding and prior gomenoh is correct?