### PR TITLE
reset error message when unknown error is happened

### DIFF
--- a/menoh/menoh.cpp
+++ b/menoh/menoh.cpp
@@ -64,6 +64,7 @@ menoh_error_code check_error(Func func) {
         menoh_impl::set_last_error_message(e.what());
         return menoh_error_code_std_error; //
     } catch(...) {
+        menoh_impl::set_last_error_message("");
         return menoh_error_code_unknown_error; //
     }
     return menoh_error_code_success;


### PR DESCRIPTION
This resets error message when unknown error is happened
Otherwise caller of `menoh_get_last_error_message()` receives a message for previous error instead of the one for the current unknown error.