### PR TITLE
Run `protoc` for ONNX at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,14 +56,7 @@ include(ExternalProject)
 include(SetupProtobuf)
 
 # Generate source codes from ONNX protobuf schema
-set(ONNX_DIR ${EXTERNAL_DIR}/onnx)
-execute_process(COMMAND git submodule update --init -- ${ONNX_DIR} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-execute_process(COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} -I=${ONNX_DIR} --cpp_out=${ONNX_DIR} ${ONNX_DIR}/onnx/onnx.proto WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ONNX_PROTO_HEADER ${ONNX_DIR}/onnx/onnx.pb.h)
-set(ONNX_PROTO_SRC ${ONNX_DIR}/onnx/onnx.pb.cc)
-
-include_directories(${ONNX_DIR}) # for ONNX_PROTO_HEADER
+include(GenerateOnnxSrc)
 
 # Setup MKLDNN
 find_package(MKLDNN "0.14")

--- a/cmake/GenerateOnnxSrc.cmake
+++ b/cmake/GenerateOnnxSrc.cmake
@@ -1,0 +1,25 @@
+set(ONNX_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/onnx)
+
+if(NOT EXISTS "${ONNX_OUTPUT_DIR}")
+    file(MAKE_DIRECTORY "${ONNX_OUTPUT_DIR}")
+endif()
+
+set(ONNX_SRC_DIR ${EXTERNAL_DIR}/onnx)
+execute_process(COMMAND git submodule update --init -- ${ONNX_SRC_DIR} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ONNX_PROTO_HEADER ${ONNX_OUTPUT_DIR}/onnx/onnx.pb.h)
+set(ONNX_PROTO_SRC ${ONNX_OUTPUT_DIR}/onnx/onnx.pb.cc)
+
+set(ONNX_GENERATED_OUTPUTS ${ONNX_PROTO_HEADER} ${ONNX_PROTO_SRC})
+
+add_custom_target(gen_onnx_outputs DEPENDS ${ONNX_GENERATED_OUTPUTS})
+add_custom_command(
+    OUTPUT ${ONNX_GENERATED_OUTPUTS}
+    COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+    ARGS -I ${ONNX_SRC_DIR} --cpp_out . ${ONNX_SRC_DIR}/onnx/onnx.proto
+    DEPENDS ${PROTOBUF_PROTOC_EXECUTABLE} ${ONNX_SRC_DIR}/onnx/onnx.proto
+    COMMENT "Generating ONNX source files"
+    WORKING_DIRECTORY ${ONNX_OUTPUT_DIR}
+    VERBATIM)
+
+include_directories(${ONNX_OUTPUT_DIR}) # for ONNX_PROTO_HEADER

--- a/menoh/CMakeLists.txt
+++ b/menoh/CMakeLists.txt
@@ -19,9 +19,17 @@ endif()
 
 file(GLOB_RECURSE SOURCES "." "*.cpp")
 
-add_library(menoh_objlib OBJECT ${SOURCES} ${ONNX_PROTO_SRC} ${ONNX_PROTO_HEADER})
+# Create a object library for generating shared library
+add_library(menoh_objlib OBJECT ${SOURCES})
+
+add_dependencies(menoh_objlib gen_onnx_outputs)
+target_sources(menoh_objlib PRIVATE ${ONNX_PROTO_SRC})
+
 set_target_properties(menoh_objlib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+include(ConfigureMenoh)
+
+# menoh
 add_library(menoh SHARED $<TARGET_OBJECTS:menoh_objlib>)
 if(NOT APPLE AND NOT MSVC)
     # Remove private symbols (Note: it works in MINGW but not in MSVC)
@@ -29,13 +37,10 @@ if(NOT APPLE AND NOT MSVC)
         TARGET menoh APPEND_STRING PROPERTY
             LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/menoh.map")
 endif()
-
-# Used in test/ subdirectory
-add_library(menoh_test_target SHARED $<TARGET_OBJECTS:menoh_objlib>)
-
-include(ConfigureMenoh)
-
 menoh_link_libraries(menoh PRIVATE)
+
+# menoh_test_target: only used in `test` subdirectory
+add_library(menoh_test_target SHARED $<TARGET_OBJECTS:menoh_objlib>)
 menoh_link_libraries(menoh_test_target PRIVATE)
 
 set_source_files_properties(${ONNX_PROTO_SRC} PROPERTIES GENERATED TRUE)

--- a/menoh/onnx.cpp
+++ b/menoh/onnx.cpp
@@ -12,7 +12,7 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
-#include <external/onnx/onnx/onnx.pb.h>
+#include <onnx/onnx.pb.h>
 
 #include <menoh/array.hpp>
 #include <menoh/dtype.hpp>


### PR DESCRIPTION
Run `protoc` for ONNX schema file at build time by using `add_custom_command` instead of `execute_process`. It also moves the output directory from `external` to `${CMAKE_CURRENT_BINARY_DIR}` (a.k.a `build/`).

Fixes #79.
