### PR TITLE
Enable LINK_STATIC_LIBPROTOBUF option on MINGW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ image:
 environment:
   matrix:
     - TARGET: mingw
+    - TARGET: mingw
+      STATIC: 1
     - TARGET: msvc
 
 install:
@@ -57,7 +59,14 @@ build_script:
 - cd build
 - if [%TARGET%]==[msvc] set PATH=%PATH%;c:\protobuf-3.6.0-msvc\bin;c:\protobuf-3.6.0-msvc\include;c:\protobuf-3.6.0-msvc\lib;c:\projects\menoh\mkl-dnn-0.15-win64\bin;c:\projects\menoh\mkl-dnn-0.15-win64\include;c:\projects\menoh\mkl-dnn-0.15-win64\lib
 - if [%TARGET%]==[mingw] (
-    cmake -G "MSYS Makefiles" -DENABLE_TEST=ON -DCMAKE_INSTALL_PREFIX=/mingw64 .. &&
+    if [%STATIC%]==[1] (
+      set STATIC_OPTION="-DLINK_STATIC_LIBPROTOBUF=ON -DLINK_STATIC_LIBSTDCXX=ON -DLINK_STATIC_LIBGCC=ON"
+    ) else (
+      set STATIC_OPTION=""
+    )
+  )
+- if [%TARGET%]==[mingw] (
+    cmake -G "MSYS Makefiles" -DENABLE_TEST=ON -DLINK_STATIC_LIBPROTOBUF=ON -DCMAKE_INSTALL_PREFIX=/mingw64 .. &&
     make
   ) else (
     cmake -G "Visual Studio 14 Win64" -DENABLE_TEST=OFF -DENABLE_BENCHMARK=OFF -DENABLE_EXAMPLE=OFF -DENABLE_TOOL=OFF -DCMAKE_INSTALL_PREFIX=c:\menoh-%MENOH_REV%-msvc .. &&

--- a/cmake/SetupProtobuf.cmake
+++ b/cmake/SetupProtobuf.cmake
@@ -6,9 +6,10 @@ if(LINK_STATIC_LIBPROTOBUF)
     # build it by ourselves.
 
     if(UNIX)
-        set(PROTOBUF_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf-${PROTOBUF_VERSION})
-        set(PROTOBUF_URL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-${PROTOBUF_VERSION}.tar.gz")
-        set(PROTOBUF_HASH MD5=f3916ce13b7fcb3072a1fa8cf02b2423)
+        set(PROTOBUF_VERSION_STATIC "3.6.1")
+        set(PROTOBUF_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf-${PROTOBUF_VERSION_STATIC})
+        set(PROTOBUF_URL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION_STATIC}/protobuf-cpp-${PROTOBUF_VERSION_STATIC}.tar.gz")
+        set(PROTOBUF_HASH MD5=406d5b8636576b1c86730ca5cbd1e576)
 
         # Requires `-fPIC` for linking with a shared library
         set(PROTOBUF_CFLAGS -fPIC)

--- a/cmake/SetupProtobuf.cmake
+++ b/cmake/SetupProtobuf.cmake
@@ -5,7 +5,7 @@ if(LINK_STATIC_LIBPROTOBUF)
     # because `libprotobuf.a` produced by the package manager is not PIC. So we need to
     # build it by ourselves.
 
-    if(UNIX)
+    if(UNIX OR MINGW)
         set(PROTOBUF_VERSION_STATIC "3.6.1")
         set(PROTOBUF_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf-${PROTOBUF_VERSION_STATIC})
         set(PROTOBUF_URL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION_STATIC}/protobuf-cpp-${PROTOBUF_VERSION_STATIC}.tar.gz")


### PR DESCRIPTION
This PR enables `LINK_STATIC_LIBPROTOBUF` option on MINGW and adds a AppVeyor job for building a binary that statically links `libprotobuf`, `libstdc++`, and `libgcc`.

This PR is intended to be merged after #82 is merged, since this branch is forked from that branch.
