### PR TITLE
Remove `Libs.private`

### DIFF
--- a/include/menoh.pc.in
+++ b/include/menoh.pc.in
@@ -8,5 +8,4 @@ Description: DNN inference library written in C++
 Version: @MENOH_MAJOR_VERSION@.@MENOH_MINOR_VERSION@.@MENOH_PATCH_VERSION@
 
 Libs: -L${libdir} -lmenoh
-Libs.private: @MKLDNN_LIBRARY@ @PROTOBUF_LIBRARY@
 Cflags: -I${includedir}


### PR DESCRIPTION
As pointed out in https://github.com/pfnet-research/menoh/pull/70#issuecomment-416903415, we don't provide a static library version of Menoh at the moment. So let's remove `Libs.private`.