### PR TITLE
Add suffix to MKL-DNN installation directory on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,14 @@ matrix:
                       - libopencv-dev
 env:
     global:
+        - MKL_DNN_REV: v0.15
+        - MKL_DNN_INSTALL_SUFFIX: -0.15
         # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
         #   via the "travis encrypt" command using the project repo's public key
         - secure: "q1I4YsB5VcNaF9Unmm6T92ht9/KwOGbxZVCpXIp5XUVulpaZq7sTd3rL1v3r1mUCYaabkcy9N4UPQjJZsuOlU4jc8zPzPxPir7hOER5umlkfSMuc1RhmShT8cK9naznqv7FLSTIjTZIao85Lrgxgw0B6xzcWc0kSeJPJVAmS5kwmC/FCQS2MPQpyhfE5JjpUrePOT+lRTB6Psm5bWyEww8bPsatO2k5b8DDdmUJIxmuJ1UTCx5rj/ZcTJLWAsj8D7u9aUfCmOhV5+hqHBvJd/06FLt254SNmvzmVLW9CVU/aZvuTtRECgBYCVndR7NxWpRHo1SBKqgLu+cNOFoFyt++1V+FAbpxj9JMktZNyxWp22c/FvBBdHynOsxBxVFdGIzhcwhQMiHFLOK3pnyiByabtINhERqrszkbpztOepBE3o8PGpjOz8iIx1TtLgmWwAw5D6WXx8FeP5FMkJwpXckCMI5tX5wPoU8cpZIwPjCxG3Z+ojHw+80pQWCrMZnEDfcf9zskJNsmv/GbiWGEvI8xVG0gst5VmjaAXK7JhC0cKvPOEmCFRGY+BWdjD3dkYIIElUmBRfTRDpcDJV6j5r1xMv7QKRFDfAjnC33KLJo2aALZTrkRPveIP2h2jU13ZbemN8GKWwEWNzidmwtCbH4rpe80rFqASWkyfii7HrEI="
 cache:
     directories:
-        - $HOME/mkl-dnn
+        - $HOME/mkl-dnn${MKL_DNN_INSTALL_SUFFIX}
 before_install:
     - |
       if [ "$TRAVIS_OS_NAME" = "linux" ]; then
@@ -84,7 +86,7 @@ before_script:
       fi
       cmake --version
       make --version
-    - ls -R $HOME/mkl-dnn
+    - ls -R $HOME/mkl-dnn${MKL_DNN_INSTALL_SUFFIX}
 script:
     #- if [ -f cov-int/build-log.txt ]; then cat cov-int/build-log.txt; fi
     # CMakeCache.txt generated for coverity_scan build hinders out-of-source build
@@ -108,8 +110,8 @@ script:
         ..
       else
         cmake -DENABLE_TEST=ON \
-        -DMKLDNN_INCLUDE_DIR="$HOME/mkl-dnn/include" \
-        -DMKLDNN_LIBRARY="$HOME/mkl-dnn/lib/libmkldnn.so" \
+        -DMKLDNN_INCLUDE_DIR="$HOME/mkl-dnn${MKL_DNN_INSTALL_SUFFIX}/include" \
+        -DMKLDNN_LIBRARY="$HOME/mkl-dnn${MKL_DNN_INSTALL_SUFFIX}/lib/libmkldnn.so" \
         $STATIC_OPTION \
         ..
       fi

--- a/.travis/install_mkldnn.sh
+++ b/.travis/install_mkldnn.sh
@@ -1,11 +1,11 @@
-if [ ! -d "$HOME/mkl-dnn/lib" ]; then
+if [ ! -d "$HOME/mkl-dnn${MKL_DNN_INSTALL_SUFFIX}/lib" ]; then
     git clone https://github.com/intel/mkl-dnn.git
     cd mkl-dnn
-    git checkout v0.15
+    git checkout $MKL_DNN_REV
     cd scripts && bash ./prepare_mkl.sh && cd ..
     sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt
     sed -i 's/add_subdirectory(tests)//g' CMakeLists.txt
-    mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/mkl-dnn .. && make
+    mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/mkl-dnn${MKL_DNN_INSTALL_SUFFIX} .. && make
     make install
     cd ..
 else


### PR DESCRIPTION
This is desirable because the cache is invalidated when MKL-DNN is upgraded.