### PR TITLE
add make_model_data_from_onnx_data_on_memory()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.1)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(MENOH_MAJOR_VERSION 1)
-set(MENOH_MINOR_VERSION 0)
-set(MENOH_PATCH_VERSION 3)
+set(MENOH_MINOR_VERSION 1)
+set(MENOH_PATCH_VERSION 0)
 
 # Options
 option(BUILD_SHARED_LIBS "Build shared libs" ON)

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -89,6 +89,8 @@ typedef struct menoh_model_data* menoh_model_data_handle;
 menoh_error_code MENOH_API menoh_make_model_data_from_onnx(
   const char* onnx_filename, menoh_model_data_handle* dst_handle);
 /*! \brief make model_data from onnx binary data on memory
+ *
+ * \note Users can free onnx_data buffer after calling menoh_make_model_data_from_onnx().
  */
 menoh_error_code MENOH_API menoh_make_model_data_from_onnx_data_on_memory(
   const uint8_t* onnx_data, int32_t size, menoh_model_data_handle* dst_handle);

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -88,6 +88,10 @@ typedef struct menoh_model_data* menoh_model_data_handle;
  */
 menoh_error_code MENOH_API menoh_make_model_data_from_onnx(
   const char* onnx_filename, menoh_model_data_handle* dst_handle);
+/*! \brief make model_data from onnx binary data on memory
+ */
+menoh_error_code MENOH_API menoh_make_model_data_from_onnx_data_on_memory(
+  const uint8_t* onnx_data, int32_t size, menoh_model_data_handle* dst_handle);
 /*! \brief Model_data delete function
  *
  * Users must call to release memory resources allocated for

--- a/include/menoh/menoh.hpp
+++ b/include/menoh/menoh.hpp
@@ -118,6 +118,15 @@ namespace menoh {
           menoh_make_model_data_from_onnx(onnx_filename.c_str(), &h));
         return model_data(h);
     }
+    //! Make model_data from onnx binary data on memory
+    inline model_data
+    make_model_data_from_onnx_data_on_memory(const uint8_t* onnx_data,
+                                             uint32_t size) {
+        menoh_model_data_handle h;
+        MENOH_CPP_API_ERROR_CHECK(
+          menoh_make_model_data_from_onnx_data_on_memory(onnx_data, size, &h));
+        return model_data(h);
+    }
     /** @} */
 
     /** @addtogroup cpp_vpt Veriable profile table

--- a/menoh/menoh.cpp
+++ b/menoh/menoh.cpp
@@ -36,7 +36,9 @@ namespace menoh_impl {
             auto cont =
               std::copy(prefix, prefix + std::char_traits<char>::length(prefix),
                         arr.begin());
-            std::copy(message, message + (static_cast<size_t>(arr.end() - cont) - 1), cont);
+            std::copy(message,
+                      message + (static_cast<size_t>(arr.end() - cont) - 1),
+                      cont);
 
         } else {
             std::copy(message, message + message_size, arr.data());
@@ -81,8 +83,21 @@ menoh_error_code
 menoh_make_model_data_from_onnx(const char* onnx_filename,
                                 menoh_model_data_handle* dst_handle) {
     return check_error([&]() {
+        *dst_handle =
+          std::make_unique<menoh_model_data>(
+            menoh_model_data{
+              menoh_impl::make_model_data_from_onnx_file(onnx_filename)})
+            .release();
+        return menoh_error_code_success;
+    });
+}
+menoh_error_code menoh_make_model_data_from_onnx_data_on_memory(
+  const uint8_t* onnx_data, int32_t size, menoh_model_data_handle* dst_handle) {
+    return check_error([&]() {
         *dst_handle = std::make_unique<menoh_model_data>(
-                        menoh_model_data{menoh_impl::load_onnx(onnx_filename)})
+                        menoh_model_data{
+                          menoh_impl::make_model_data_from_onnx_data_on_memory(
+                            onnx_data, size)})
                         .release();
         return menoh_error_code_success;
     });

--- a/menoh/model_data.hpp
+++ b/menoh/model_data.hpp
@@ -2,10 +2,10 @@
 #define MENOH_MODEL_DATA_HPP
 
 #include <algorithm>
+#include <iterator>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <iterator>
 
 #include <menoh/array.hpp>
 #include <menoh/graph.hpp>

--- a/menoh/node.hpp
+++ b/menoh/node.hpp
@@ -20,7 +20,6 @@ namespace menoh_impl {
     };
 
     bool operator==(node const& a, node const& b);
-    inline bool operator!=(node const& a, node const& b) { return !(a == b); }
     bool operator<(node const& a, node const& b);
 
     int optional_attribute_int(node const& n, std::string const& attr_name,

--- a/menoh/node.hpp
+++ b/menoh/node.hpp
@@ -20,6 +20,7 @@ namespace menoh_impl {
     };
 
     bool operator==(node const& a, node const& b);
+    inline bool operator!=(node const& a, node const& b) { return !(a == b); }
     bool operator<(node const& a, node const& b);
 
     int optional_attribute_int(node const& n, std::string const& attr_name,
@@ -47,11 +48,11 @@ namespace menoh_impl {
                         std::unordered_map<std::string, std::vector<int>> const&
                           variable_dims_table);
 
-    std::vector<int>
-    calc_2d_output_dims_for_conv_transpose(menoh_impl::node const& node, int output_channel_num,
-                        std::unordered_map<std::string, std::vector<int>> const&
-                          variable_dims_table);
-                          
+    std::vector<int> calc_2d_output_dims_for_conv_transpose(
+      menoh_impl::node const& node, int output_channel_num,
+      std::unordered_map<std::string, std::vector<int>> const&
+        variable_dims_table);
+
 } // namespace menoh_impl
 
 #endif // MENOH_NODE_HPP

--- a/menoh/onnx.cpp
+++ b/menoh/onnx.cpp
@@ -232,10 +232,6 @@ namespace menoh_impl {
     model_data make_model_data_from_onnx_data_on_memory(const uint8_t* onnx_data, int32_t size) {
         namespace gpio = ::google::protobuf::io;
         gpio::ArrayInputStream ais(onnx_data, size);
-        /*
-        ais.SetTotalBytesLimit(std::numeric_limits<int>::max(),
-                               std::numeric_limits<int>::max());
-        */
         onnx::ModelProto onnx_model;
         if(!onnx_model.ParseFromZeroCopyStream(&ais)) {
             throw onnx_parse_error("parse binary onnx data on memory");

--- a/menoh/onnx.cpp
+++ b/menoh/onnx.cpp
@@ -23,24 +23,6 @@
 
 namespace menoh_impl {
 
-    onnx::ModelProto load_onnx_model_proto(std::string const& filename) {
-        namespace gpio = ::google::protobuf::io;
-
-        std::ifstream ifs(filename, std::ios::binary);
-        if(!ifs) {
-            throw invalid_filename(filename);
-        }
-        gpio::IstreamInputStream iis(&ifs);
-        gpio::CodedInputStream cis(&iis);
-        cis.SetTotalBytesLimit(std::numeric_limits<int>::max(),
-                               std::numeric_limits<int>::max());
-        onnx::ModelProto onnx_model;
-        if(!onnx_model.ParseFromCodedStream(&cis)) {
-            throw onnx_parse_error(filename);
-        }
-        return onnx_model;
-    }
-
     auto tensor_proto_data_type_to_dtype(onnx::TensorProto_DataType tpdt) {
         if(tpdt == onnx::TensorProto_DataType_FLOAT) {
             return dtype_t::float_;
@@ -185,15 +167,14 @@ namespace menoh_impl {
         return node_list;
     }
 
-    model_data load_onnx(std::string const& filename) {
-        auto onnx_model = load_onnx_model_proto(filename);
 
+    model_data make_model_from_onnx(onnx::ModelProto& onnx_model) {
         // onnx opset version check
         if(onnx_model.opset_import_size() != 0) {
             int version = onnx_model.opset_import(0).version();
             if(MENOH_SUPPORTED_ONNX_OPSET_VERSION < version) {
                 throw unsupported_onnx_opset_version(
-                  filename, version, MENOH_SUPPORTED_ONNX_OPSET_VERSION);
+                  version, MENOH_SUPPORTED_ONNX_OPSET_VERSION);
             }
         }
 
@@ -228,6 +209,38 @@ namespace menoh_impl {
           extract_parameter_name_and_array_list_from_onnx_graph(
             *onnx_model.mutable_graph(), model_parameter_name_list);
         return model_data{node_list, parameter_table};
+    }
+
+    model_data make_model_data_from_onnx_file(std::string const& filename) {
+        namespace gpio = ::google::protobuf::io;
+
+        std::ifstream ifs(filename, std::ios::binary);
+        if(!ifs) {
+            throw invalid_filename(filename);
+        }
+        gpio::IstreamInputStream iis(&ifs);
+        gpio::CodedInputStream cis(&iis);
+        cis.SetTotalBytesLimit(std::numeric_limits<int>::max(),
+                               std::numeric_limits<int>::max());
+        onnx::ModelProto onnx_model;
+        if(!onnx_model.ParseFromCodedStream(&cis)) {
+            throw onnx_parse_error(filename);
+        }
+        return make_model_from_onnx(onnx_model);
+    }
+
+    model_data make_model_data_from_onnx_data_on_memory(const uint8_t* onnx_data, int32_t size) {
+        namespace gpio = ::google::protobuf::io;
+        gpio::ArrayInputStream ais(onnx_data, size);
+        /*
+        ais.SetTotalBytesLimit(std::numeric_limits<int>::max(),
+                               std::numeric_limits<int>::max());
+        */
+        onnx::ModelProto onnx_model;
+        if(!onnx_model.ParseFromZeroCopyStream(&ais)) {
+            throw onnx_parse_error("parse binary onnx data on memory");
+        }
+        return make_model_from_onnx(onnx_model);
     }
 
     std::vector<std::string>

--- a/menoh/onnx.hpp
+++ b/menoh/onnx.hpp
@@ -21,14 +21,13 @@ namespace menoh_impl {
 
     class unsupported_onnx_opset_version : public exception {
     public:
-        unsupported_onnx_opset_version(std::string const& filename,
-                                       int actual_version,
+        unsupported_onnx_opset_version(int actual_version,
                                        int supported_version)
-          : exception(
-              menoh_error_code_unsupported_onnx_opset_version,
-              "menoh unsupported onnx opset version error: " + filename +
-                " has onnx opset version " + std::to_string(actual_version) +
-                " > " + std::to_string(supported_version)) {}
+          : exception(menoh_error_code_unsupported_onnx_opset_version,
+                      "menoh unsupported onnx opset version error: given onnx "
+                      "has opset version " +
+                        std::to_string(actual_version) + " > " +
+                        std::to_string(supported_version)) {}
     };
 
     class invalid_attribute_type : public exception {
@@ -40,7 +39,10 @@ namespace menoh_impl {
                         attribute_type + " for \"" + attribute_name + "\"") {}
     };
 
-    model_data load_onnx(std::string const& filename);
+    model_data make_model_data_from_onnx_file(std::string const& filename);
+    model_data
+    make_model_data_from_onnx_data_on_memory(const uint8_t* onnx_data,
+                                             int32_t size);
 
     std::vector<std::string>
     extract_model_input_name_list(menoh_impl::model_data const& model_data);

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -1,6 +1,8 @@
 #ifndef MENOH_TEST_COMMON_HPP
 #define MENOH_TEST_COMMON_HPP
 
+#include <menoh/array.hpp>
+
 namespace menoh_impl {
 
     template <typename Iter1, typename Iter2>
@@ -23,7 +25,8 @@ namespace menoh_impl {
     }
 
     template <typename Iter1, typename Iter2>
-    auto assert_near_list(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2, float eps) {
+    auto assert_near_list(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2,
+                          float eps) {
         ASSERT_EQ(std::distance(first1, last1), std::distance(first2, last2))
           << "size is different";
         int i = 0;
@@ -40,8 +43,27 @@ namespace menoh_impl {
     auto assert_near_list(List1 const& list1, List2 const& list2, float eps) {
         using std::begin;
         using std::end;
-        assert_near_list(begin(list1), end(list1), begin(list2), end(list2), eps);
+        assert_near_list(begin(list1), end(list1), begin(list2), end(list2),
+                         eps);
     }
-}
+
+    inline bool is_near_array(array const& lhs, array const& rhs,
+                              float eps = 1e-4) {
+        assert(lhs.dtype() == dtype_t::float_);
+        assert(rhs.dtype() == dtype_t::float_);
+        if(total_size(lhs) != total_size(rhs)) {
+            return false;
+        }
+        auto size = total_size(lhs);
+        for(auto i = 0; i < size; ++i) {
+            float l = *(static_cast<float*>(lhs.data()) + i);
+            float r = *(static_cast<float*>(rhs.data()) + i);
+            if(!(l - eps < r && r < l + eps)) {
+                return false;
+            }
+        }
+        return true;
+    }
+} // namespace menoh_impl
 
 #endif // MENOH_TEST_COMMON_HPP

--- a/test/mkldnn.cpp
+++ b/test/mkldnn.cpp
@@ -21,7 +21,8 @@ namespace menoh_impl {
 
         TEST_F(MKLDNNTest, run_onnx_model) {
             static mkldnn::engine engine(mkldnn::engine::cpu, 0);
-            auto model_data = load_onnx("../data/VGG16.onnx");
+            auto model_data =
+              make_model_data_from_onnx_file("../data/VGG16.onnx");
             // model_data = trim_redundant_nodes(model_data);
 
             auto input_name_list = extract_model_input_name_list(model_data);
@@ -78,7 +79,8 @@ namespace menoh_impl {
             std::vector<int> input_dims{batch_size, channel_num, height, width};
 
             // Load ONNX model data
-            auto model_data = menoh_impl::load_onnx("../data/VGG16.onnx");
+            auto model_data =
+              menoh_impl::make_model_data_from_onnx_file("../data/VGG16.onnx");
 
             auto cpu_count =
               mkldnn::engine::get_count(mkldnn::engine::kind::cpu);

--- a/test/model.cpp
+++ b/test/model.cpp
@@ -28,7 +28,7 @@ namespace menoh_impl {
 
             // Load ONNX model data
             auto model_data = std::make_unique<menoh_impl::model_data>(
-              menoh_impl::load_onnx("../data/VGG16.onnx"));
+              menoh_impl::make_model_data_from_onnx_file("../data/VGG16.onnx"));
 
             // Construct computation primitive list and memories
             auto model = menoh_impl::model(

--- a/test/onnx.cpp
+++ b/test/onnx.cpp
@@ -85,9 +85,13 @@ namespace menoh_impl {
                   model_data_from_file.parameter_name_and_array_list.begin(),
                   model_data_from_file.parameter_name_and_array_list.end(),
                   [&p](auto e) { return e.first == p.first; });
+
+                // check if param which has same name is found
                 ASSERT_NE(
                   param_iter,
                   model_data_from_file.parameter_name_and_array_list.end());
+
+                // check if parameter has same values
                 ASSERT_TRUE(is_near_array(p.second, param_iter->second));
             }
         }

--- a/test/onnx.cpp
+++ b/test/onnx.cpp
@@ -7,13 +7,18 @@
 
 #include <menoh/model_data.hpp>
 #include <menoh/onnx.hpp>
+#include "common.hpp"
 
 namespace menoh_impl {
     namespace {
-        class ONNXTest : public ::testing::Test {};
+        class ONNXTest : public ::testing::Test {
+        public:
+            std::string model_filename{"../data/VGG16.onnx"};
+        };
 
-        TEST_F(ONNXTest, load_onnx_model) {
-            auto model_data = menoh_impl::load_onnx("../data/VGG16.onnx");
+        TEST_F(ONNXTest, make_model_data_from_onnx_file) {
+            auto model_data =
+              menoh_impl::make_model_data_from_onnx_file(model_filename);
             std::cout << "param table" << std::endl;
             std::cout << "node list size: " << model_data.node_list.size()
                       << std::endl;
@@ -43,6 +48,46 @@ namespace menoh_impl {
             std::cout << "output_name_set" << std::endl;
             for(auto const& output_name : output_name_list) {
                 std::cout << output_name << std::endl;
+            }
+        }
+
+        TEST_F(ONNXTest, make_model_data_from_onnx_data_on_memory) {
+            std::fstream input(model_filename, std::ios::in | std::ios::binary);
+            std::istreambuf_iterator<char> begin(input);
+            std::istreambuf_iterator<char> end;
+            std::vector<char> buffer(begin, end);
+            auto model_data_from_memory =
+              make_model_data_from_onnx_data_on_memory(
+                static_cast<uint8_t*>(static_cast<void*>(buffer.data())),
+                buffer.size());
+
+            auto model_data_from_file =
+              menoh_impl::make_model_data_from_onnx_file(model_filename);
+
+            ASSERT_EQ(model_data_from_memory.node_list.size(),
+                      model_data_from_file.node_list.size());
+
+            std::sort(model_data_from_memory.node_list.begin(),
+                      model_data_from_memory.node_list.end());
+            std::sort(model_data_from_file.node_list.begin(),
+                      model_data_from_file.node_list.end());
+            ASSERT_EQ(model_data_from_memory.node_list,
+                      model_data_from_file.node_list);
+
+            ASSERT_EQ(
+              model_data_from_memory.parameter_name_and_array_list.size(),
+              model_data_from_file.parameter_name_and_array_list.size());
+
+            for(auto const& p :
+                model_data_from_memory.parameter_name_and_array_list) {
+                auto param_iter = std::find_if(
+                  model_data_from_file.parameter_name_and_array_list.begin(),
+                  model_data_from_file.parameter_name_and_array_list.end(),
+                  [&p](auto e) { return e.first == p.first; });
+                ASSERT_NE(
+                  param_iter,
+                  model_data_from_file.parameter_name_and_array_list.end());
+                ASSERT_TRUE(is_near_array(p.second, param_iter->second));
             }
         }
 

--- a/test/onnx.cpp
+++ b/test/onnx.cpp
@@ -61,6 +61,7 @@ namespace menoh_impl {
               make_model_data_from_onnx_data_on_memory(
                 static_cast<uint8_t*>(static_cast<void*>(buffer.data())),
                 buffer.size());
+            buffer.clear(); // buffer can be cleared here
 
             auto model_data_from_file =
               menoh_impl::make_model_data_from_onnx_file(model_filename);

--- a/test/onnx.cpp
+++ b/test/onnx.cpp
@@ -7,6 +7,7 @@
 
 #include <menoh/model_data.hpp>
 #include <menoh/onnx.hpp>
+
 #include "common.hpp"
 
 namespace menoh_impl {
@@ -52,7 +53,7 @@ namespace menoh_impl {
         }
 
         TEST_F(ONNXTest, make_model_data_from_onnx_data_on_memory) {
-            std::fstream input(model_filename, std::ios::in | std::ios::binary);
+            std::ifstream input(model_filename, std::ios::binary);
             std::istreambuf_iterator<char> begin(input);
             std::istreambuf_iterator<char> end;
             std::vector<char> buffer(begin, end);


### PR DESCRIPTION
`make_model_data_from_onnx_data_on_memory()` enables to construct `model_data` from ONNX protobuf serialized binary data on memory.