### PR TITLE
Change add input profile api

### DIFF
--- a/example/vgg16_example_in_c.c
+++ b/example/vgg16_example_in_c.c
@@ -29,8 +29,9 @@ int main() {
     menoh_variable_profile_table_builder_handle vpt_builder;
     ERROR_CHECK(menoh_make_variable_profile_table_builder(&vpt_builder));
 
-    ERROR_CHECK(menoh_variable_profile_table_builder_add_input_profile_dims_4(
-      vpt_builder, conv1_1_in_name, menoh_dtype_float, 1, 3, 224, 224));
+    const int32_t input_dims[] = {1, 3, 224, 224};
+    ERROR_CHECK(menoh_variable_profile_table_builder_add_input_profile(
+      vpt_builder, conv1_1_in_name, menoh_dtype_float, 4, input_dims));
 
     ERROR_CHECK(menoh_variable_profile_table_builder_add_output_profile(
       vpt_builder, fc6_out_name, menoh_dtype_float));

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -24,12 +24,10 @@
 
 #ifdef __cplusplus
 #define MENOH_DEPRECATED_ATTRIBUTE( message ) [[deprecated( message )]]
-#else
-#if (defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
+#elif (defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
 #define MENOH_DEPRECATED_ATTRIBUTE( message ) __declspec(deprecated( message ))
 #else
 #define MENOH_DEPRECATED_ATTRIBUTE( message ) __attribute__((deprecated( message )))
-#endif
 #endif
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -22,6 +22,16 @@
 #define MENOH_ERROR_MESSAGE_MAX_LENGTH 1024
 #endif
 
+#ifdef __cplusplus
+#define MENOH_DEPRECATED_ATTRIBUTE( message ) [[deprecated( message )]]
+#else
+#if (defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
+#define MENOH_DEPRECATED_ATTRIBUTE( message ) __declspec(deprecated( message ))
+#else
+#define MENOH_DEPRECATED_ATTRIBUTE( message ) __attribute__((deprecated( message )))
+#endif
+#endif
+
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 #ifdef __cplusplus
@@ -141,7 +151,7 @@ menoh_variable_profile_table_builder_add_input_profile(
  * Input profile contains name, dtype and dims (num, size). This 2D input is
  * conventional batched 1D inputs.
  */
-[[deprecated("please use menoh_variable_profile_table_builder_add_input_profile() instead")]]
+MENOH_DEPRECATED_ATTRIBUTE("please use menoh_variable_profile_table_builder_add_input_profile() instead")
 menoh_error_code MENOH_API
 menoh_variable_profile_table_builder_add_input_profile_dims_2(
   menoh_variable_profile_table_builder_handle builder, const char* name,
@@ -153,7 +163,7 @@ menoh_variable_profile_table_builder_add_input_profile_dims_2(
  * This 4D input is conventional batched image inputs. Image input is
  * 3D(channel, height, width).
  */
-[[deprecated("please use menoh_variable_profile_table_builder_add_input_profile() instead")]]
+MENOH_DEPRECATED_ATTRIBUTE("please use menoh_variable_profile_table_builder_add_input_profile() instead")
 menoh_error_code MENOH_API
 menoh_variable_profile_table_builder_add_input_profile_dims_4(
   menoh_variable_profile_table_builder_handle builder, const char* name,

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -136,6 +136,30 @@ menoh_variable_profile_table_builder_add_input_profile(
   menoh_variable_profile_table_builder_handle builder, const char* name,
   menoh_dtype dtype, int32_t dims_size, const int32_t* dims);
 
+/*! \brief Add 2D input profile
+ *
+ * Input profile contains name, dtype and dims (num, size). This 2D input is
+ * conventional batched 1D inputs.
+ */
+[[deprecated("please use menoh_variable_profile_table_builder_add_input_profile() instead")]]
+menoh_error_code MENOH_API
+menoh_variable_profile_table_builder_add_input_profile_dims_2(
+  menoh_variable_profile_table_builder_handle builder, const char* name,
+  menoh_dtype dtype, int32_t num, int32_t size);
+
+/*! \brief Add 4D input profile
+ *
+ * Input profile contains name, dtype and dims (num, channel, height, width).
+ * This 4D input is conventional batched image inputs. Image input is
+ * 3D(channel, height, width).
+ */
+[[deprecated("please use menoh_variable_profile_table_builder_add_input_profile() instead")]]
+menoh_error_code MENOH_API
+menoh_variable_profile_table_builder_add_input_profile_dims_4(
+  menoh_variable_profile_table_builder_handle builder, const char* name,
+  menoh_dtype dtype, int32_t num, int32_t channel, int32_t height,
+  int32_t width);
+
 /*! \brief Add output profile
  *
  * Output profile contains name and dtype. Its dims are calculated automatically

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -108,8 +108,7 @@ void MENOH_API menoh_delete_model_data(menoh_model_data_handle model_data);
  * This struct configure profiles of variables.
  *
  * See
- *  - menoh_variable_profile_table_builder_add_input_profile_dims_2()
- *  - menoh_variable_profile_table_builder_add_input_profile_dims_4()
+ *  - menoh_variable_profile_table_builder_add_input_profile()
  *  - menoh_variable_profile_table_builder_add_output_profile().
  */
 struct menoh_variable_profile_table_builder;
@@ -128,27 +127,14 @@ menoh_error_code MENOH_API menoh_make_variable_profile_table_builder(
 void MENOH_API menoh_delete_variable_profile_table_builder(
   menoh_variable_profile_table_builder_handle builder);
 
-/*! \brief Add 2D input profile
+/*! \brief Add input profile
  *
- * Input profile contains name, dtype and dims (num, size). This 2D input is
- * conventional batched 1D inputs.
+ * Input profile contains name, dtype and dims.
  */
 menoh_error_code MENOH_API
-menoh_variable_profile_table_builder_add_input_profile_dims_2(
+menoh_variable_profile_table_builder_add_input_profile(
   menoh_variable_profile_table_builder_handle builder, const char* name,
-  menoh_dtype dtype, int32_t num, int32_t size);
-
-/*! \brief Add 4D input profile
- *
- * Input profile contains name, dtype and dims (num, channel, height, width).
- * This 4D input is conventional batched image inputs. Image input is
- * 3D(channel, height, width).
- */
-menoh_error_code MENOH_API
-menoh_variable_profile_table_builder_add_input_profile_dims_4(
-  menoh_variable_profile_table_builder_handle builder, const char* name,
-  menoh_dtype dtype, int32_t num, int32_t channel, int32_t height,
-  int32_t width);
+  menoh_dtype dtype, int32_t dims_size, const int32_t* dims);
 
 /*! \brief Add output profile
  *

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -5,7 +5,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#if (defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
+#if(defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
 #define MENOH_API __declspec(dllexport)
 #else
 #define MENOH_API
@@ -23,11 +23,11 @@
 #endif
 
 #ifdef __cplusplus
-#define MENOH_DEPRECATED_ATTRIBUTE( message ) [[deprecated( message )]]
-#elif (defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
-#define MENOH_DEPRECATED_ATTRIBUTE( message ) __declspec(deprecated( message ))
+#define MENOH_DEPRECATED_ATTRIBUTE(message) [[deprecated(message)]]
+#elif(defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
+#define MENOH_DEPRECATED_ATTRIBUTE(message) __declspec(deprecated(message))
 #else
-#define MENOH_DEPRECATED_ATTRIBUTE( message ) __attribute__((deprecated( message )))
+#define MENOH_DEPRECATED_ATTRIBUTE(message) __attribute__((deprecated(message)))
 #endif
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
@@ -149,7 +149,8 @@ menoh_variable_profile_table_builder_add_input_profile(
  * Input profile contains name, dtype and dims (num, size). This 2D input is
  * conventional batched 1D inputs.
  */
-MENOH_DEPRECATED_ATTRIBUTE("please use menoh_variable_profile_table_builder_add_input_profile() instead")
+MENOH_DEPRECATED_ATTRIBUTE(
+  "please use menoh_variable_profile_table_builder_add_input_profile() instead")
 menoh_error_code MENOH_API
 menoh_variable_profile_table_builder_add_input_profile_dims_2(
   menoh_variable_profile_table_builder_handle builder, const char* name,
@@ -161,7 +162,8 @@ menoh_variable_profile_table_builder_add_input_profile_dims_2(
  * This 4D input is conventional batched image inputs. Image input is
  * 3D(channel, height, width).
  */
-MENOH_DEPRECATED_ATTRIBUTE("please use menoh_variable_profile_table_builder_add_input_profile() instead")
+MENOH_DEPRECATED_ATTRIBUTE(
+  "please use menoh_variable_profile_table_builder_add_input_profile() instead")
 menoh_error_code MENOH_API
 menoh_variable_profile_table_builder_add_input_profile_dims_4(
   menoh_variable_profile_table_builder_handle builder, const char* name,

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -22,12 +22,14 @@
 #define MENOH_ERROR_MESSAGE_MAX_LENGTH 1024
 #endif
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && __cplusplus >= 201402L
 #define MENOH_DEPRECATED_ATTRIBUTE(message) [[deprecated(message)]]
 #elif(defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__)
 #define MENOH_DEPRECATED_ATTRIBUTE(message) __declspec(deprecated(message))
-#else
+#elif defined(__GNUC__)
 #define MENOH_DEPRECATED_ATTRIBUTE(message) __attribute__((deprecated(message)))
+#else
+#define MENOH_DEPRECATED_ATTRIBUTE(message)
 #endif
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/include/menoh/menoh.hpp
+++ b/include/menoh/menoh.hpp
@@ -70,6 +70,8 @@ namespace menoh {
     };
     /** @} */
 
+    enum class dtype_t { float_ = menoh_dtype_float };
+
     class variable_profile_table;
 
     /** @addtogroup cpp_model_data Model data
@@ -122,7 +124,6 @@ namespace menoh {
 
     /** @addtogroup cpp_vpt Veriable profile table
      * @{ */
-    enum class dtype_t { float_ = menoh_dtype_float };
 
     struct variable_profile {
         dtype_t dtype;
@@ -199,23 +200,10 @@ namespace menoh {
         //! Add input profile. That profile contains name, dtype and dims.
         void add_input_profile(std::string const& name, dtype_t dtype,
                                std::vector<int32_t> const& dims) {
-            if(dims.size() == 2) {
-                MENOH_CPP_API_ERROR_CHECK(
-                  menoh_variable_profile_table_builder_add_input_profile_dims_2(
-                    impl_.get(), name.c_str(), static_cast<menoh_dtype>(dtype),
-                    dims.at(0), dims.at(1)));
-            } else if(dims.size() == 4) {
-                MENOH_CPP_API_ERROR_CHECK(
-                  menoh_variable_profile_table_builder_add_input_profile_dims_4(
-                    impl_.get(), name.c_str(), static_cast<menoh_dtype>(dtype),
-                    dims.at(0), dims.at(1), dims.at(2), dims.at(3)));
-            } else {
-                throw error(error_code_t::invalid_dims_size,
-                            "menoh invalid dims size error (2 or 4 is valid): "
-                            "dims size of " +
-                              name + " is specified " +
-                              std::to_string(dims.size()));
-            }
+            MENOH_CPP_API_ERROR_CHECK(
+              menoh_variable_profile_table_builder_add_input_profile(
+                impl_.get(), name.c_str(), static_cast<menoh_dtype>(dtype),
+                dims.size(), dims.data()));
         }
 
         //! Add output profile. That profile contains name, dtype.

--- a/menoh/menoh.cpp
+++ b/menoh/menoh.cpp
@@ -125,6 +125,28 @@ menoh_error_code menoh_variable_profile_table_builder_add_input_profile(
     });
 }
 
+menoh_error_code menoh_variable_profile_table_builder_add_input_profile_dims_2(
+  menoh_variable_profile_table_builder_handle builder, const char* name,
+  menoh_dtype dtype, int32_t num, int32_t size) {
+    return check_error([&]() {
+        std::vector<int> dims = {num, size};
+        builder->input_name_and_dtype_and_dims_list.push_back(
+          std::make_tuple(std::string(name), dtype, dims));
+        return menoh_error_code_success;
+    });
+}
+menoh_error_code menoh_variable_profile_table_builder_add_input_profile_dims_4(
+  menoh_variable_profile_table_builder_handle builder, const char* name,
+  menoh_dtype dtype, int32_t num, int32_t channel, int32_t height,
+  int32_t width) {
+    return check_error([&]() {
+        std::vector<int> dims = {num, channel, height, width};
+        builder->input_name_and_dtype_and_dims_list.push_back(
+          std::make_tuple(std::string(name), dtype, dims));
+        return menoh_error_code_success;
+    });
+}
+
 menoh_error_code menoh_variable_profile_table_builder_add_output_profile(
   menoh_variable_profile_table_builder_handle builder, const char* name,
   menoh_dtype dtype) {

--- a/menoh/menoh.cpp
+++ b/menoh/menoh.cpp
@@ -114,24 +114,13 @@ void menoh_delete_variable_profile_table_builder(
     delete builder;
 }
 
-menoh_error_code menoh_variable_profile_table_builder_add_input_profile_dims_2(
+menoh_error_code menoh_variable_profile_table_builder_add_input_profile(
   menoh_variable_profile_table_builder_handle builder, const char* name,
-  menoh_dtype dtype, int32_t num, int32_t size) {
+  menoh_dtype dtype, int32_t dims_size, const int32_t* dims) {
     return check_error([&]() {
-        std::vector<int> dims = {num, size};
         builder->input_name_and_dtype_and_dims_list.push_back(
-          std::make_tuple(std::string(name), dtype, dims));
-        return menoh_error_code_success;
-    });
-}
-menoh_error_code menoh_variable_profile_table_builder_add_input_profile_dims_4(
-  menoh_variable_profile_table_builder_handle builder, const char* name,
-  menoh_dtype dtype, int32_t num, int32_t channel, int32_t height,
-  int32_t width) {
-    return check_error([&]() {
-        std::vector<int> dims = {num, channel, height, width};
-        builder->input_name_and_dtype_and_dims_list.push_back(
-          std::make_tuple(std::string(name), dtype, dims));
+          std::make_tuple(std::string(name), dtype,
+                          std::vector<int32_t>(dims, dims + dims_size)));
         return menoh_error_code_success;
     });
 }


### PR DESCRIPTION
By this PR, New API `menoh_variable_profile_table_builder_add_input_profile` is added .
So `menoh_variable_profile_table_builder_add_input_profile_dims_2` and `menoh_variable_profile_table_builder_add_input_profile_dims_4` are set as deprecated.