### PR TITLE
Dockerize the build workflow on Travis CI for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build*
+build*/
 data/*
 external/protobuf/
 runx/onnx/onnx.pb.cc

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,27 +4,6 @@ language: cpp
 services:
   - docker
 addons:
-matrix:
-    include:
-        - os: osx
-          env: PLATFORM=macosx-x86_64
-        - os: osx
-          env: PLATFORM=macosx-x86_64 LINK_STATIC=true
-        - os: linux
-          env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6
-#          addons:
-#              coverity_scan:
-#                  project:
-#                      name: "pfnet-research/menoh"
-#                      description: "Menoh: DNN inference library"
-#                  notification_email: menoh-oss@preferred.jp
-#                  build_command_prepend: >-
-#                      cov-configure --compiler /usr/bin/g++-7 --comptype g++ -- -march=native -fPIC -std=gnu++14 &&
-#                      cmake .
-#                  build_command: make
-#                  branch_pattern: coverity_scan
-        - os: linux
-          env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6 LINK_STATIC=true
 
 env:
     global:
@@ -33,19 +12,76 @@ env:
         - MAKE_JOBS: 2
         # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
         #   via the "travis encrypt" command using the project repo's public key
-#        - secure: "q1I4YsB5VcNaF9Unmm6T92ht9/KwOGbxZVCpXIp5XUVulpaZq7sTd3rL1v3r1mUCYaabkcy9N4UPQjJZsuOlU4jc8zPzPxPir7hOER5umlkfSMuc1RhmShT8cK9naznqv7FLSTIjTZIao85Lrgxgw0B6xzcWc0kSeJPJVAmS5kwmC/FCQS2MPQpyhfE5JjpUrePOT+lRTB6Psm5bWyEww8bPsatO2k5b8DDdmUJIxmuJ1UTCx5rj/ZcTJLWAsj8D7u9aUfCmOhV5+hqHBvJd/06FLt254SNmvzmVLW9CVU/aZvuTtRECgBYCVndR7NxWpRHo1SBKqgLu+cNOFoFyt++1V+FAbpxj9JMktZNyxWp22c/FvBBdHynOsxBxVFdGIzhcwhQMiHFLOK3pnyiByabtINhERqrszkbpztOepBE3o8PGpjOz8iIx1TtLgmWwAw5D6WXx8FeP5FMkJwpXckCMI5tX5wPoU8cpZIwPjCxG3Z+ojHw+80pQWCrMZnEDfcf9zskJNsmv/GbiWGEvI8xVG0gst5VmjaAXK7JhC0cKvPOEmCFRGY+BWdjD3dkYIIElUmBRfTRDpcDJV6j5r1xMv7QKRFDfAjnC33KLJo2aALZTrkRPveIP2h2jU13ZbemN8GKWwEWNzidmwtCbH4rpe80rFqASWkyfii7HrEI="
+        - secure: "q1I4YsB5VcNaF9Unmm6T92ht9/KwOGbxZVCpXIp5XUVulpaZq7sTd3rL1v3r1mUCYaabkcy9N4UPQjJZsuOlU4jc8zPzPxPir7hOER5umlkfSMuc1RhmShT8cK9naznqv7FLSTIjTZIao85Lrgxgw0B6xzcWc0kSeJPJVAmS5kwmC/FCQS2MPQpyhfE5JjpUrePOT+lRTB6Psm5bWyEww8bPsatO2k5b8DDdmUJIxmuJ1UTCx5rj/ZcTJLWAsj8D7u9aUfCmOhV5+hqHBvJd/06FLt254SNmvzmVLW9CVU/aZvuTtRECgBYCVndR7NxWpRHo1SBKqgLu+cNOFoFyt++1V+FAbpxj9JMktZNyxWp22c/FvBBdHynOsxBxVFdGIzhcwhQMiHFLOK3pnyiByabtINhERqrszkbpztOepBE3o8PGpjOz8iIx1TtLgmWwAw5D6WXx8FeP5FMkJwpXckCMI5tX5wPoU8cpZIwPjCxG3Z+ojHw+80pQWCrMZnEDfcf9zskJNsmv/GbiWGEvI8xVG0gst5VmjaAXK7JhC0cKvPOEmCFRGY+BWdjD3dkYIIElUmBRfTRDpcDJV6j5r1xMv7QKRFDfAjnC33KLJo2aALZTrkRPveIP2h2jU13ZbemN8GKWwEWNzidmwtCbH4rpe80rFqASWkyfii7HrEI="
 
 cache:
-  directories:
-    - ${HOME}/downloads
-    - ${HOME}/build/protobuf-${PROTOBUF_VERSION}
-    - ${HOME}/build/mkl-dnn-${MKLDNN_VERSION}
+    directories:
+        - ${HOME}/downloads
+        - ${HOME}/build/protobuf-${PROTOBUF_VERSION}
+        - ${HOME}/build/mkl-dnn-${MKLDNN_VERSION}
 
-#before_install:
-#    - |
-#      if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-#        echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
-#      fi
+matrix:
+    include:
+        - os: osx
+          env: PLATFORM=macosx-x86_64
+        - os: osx
+          env: PLATFORM=macosx-x86_64 LINK_STATIC=true
+        - os: linux
+          env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6
+        - os: linux
+          env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6 LINK_STATIC=true
+        - os: linux
+          env: RUN_COVERITY=true
+          addons:
+              apt:
+                  sources:
+                      - ubuntu-toolchain-r-test
+                      - sourceline: 'ppa:maarten-fonville/protobuf'
+                  packages:
+                      - gcc-7
+                      - g++-7
+                      - cmake-data
+                      - cmake
+                      - libopencv-dev
+                      - libprotobuf-dev
+                      - protobuf-compiler
+              coverity_scan:
+                  project:
+                      name: "pfnet-research/menoh"
+                      description: "Menoh: DNN inference library"
+                  notification_email: menoh-oss@preferred.jp
+                  build_command_prepend: >-
+                      cov-configure --compiler /usr/bin/g++-7 --comptype g++ -- -march=native -fPIC -std=gnu++14 &&
+                      cmake .
+                  build_command: make
+                  branch_pattern: coverity_scan
+          before_install:
+              - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+          install:
+              - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CXX" = "g++" ]; then export CXX="g++-7" CC="gcc-7"; fi
+              - |
+                bash -ex ${TRAVIS_BUILD_DIR}/.travis/install-mkldnn.sh \
+                    --version ${MKLDNN_VERSION} \
+                    --download-dir ${HOME}/downloads \
+                    --build-dir ${HOME}/build \
+                    --install-dir /usr/local \
+                    --parallel ${MAKE_JOBS}
+              - pip install --user chainer
+              - |
+                bash -ex ${TRAVIS_BUILD_DIR}/.travis/prepare-menoh-data.sh \
+                    --source-dir ${TRAVIS_BUILD_DIR} \
+                    --python-executable python
+          script:
+              #- if [ -f cov-int/build-log.txt ]; then cat cov-int/build-log.txt; fi
+              # CMakeCache.txt generated for coverity_scan build hinders out-of-source build
+              - if [ -f CMakeCache.txt ]; then rm CMakeCache.txt; fi
+              - if [ -d "build" ]; then mkdir -p build; fi
+              - cd build
+              - cmake -DENABLE_TEST=ON ..
+              - make
+              - ./test/menoh_test
+              - ldd menoh/libmenoh.so
+
 script:
     - |
       echo "travis_fold:start:run-build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
           env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6
         - os: linux
           env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6 LINK_STATIC=true
+        # Use Travis directly instead of container to run static code analysis using Coverity
         - os: linux
           env: RUN_COVERITY=true
           addons:
@@ -52,7 +53,9 @@ matrix:
                   notification_email: menoh-oss@preferred.jp
                   build_command_prepend: >-
                       cov-configure --compiler /usr/bin/g++-7 --comptype g++ -- -march=native -fPIC -std=gnu++14 &&
-                      cmake .
+                          cmake
+                              -DMKLDNN_INCLUDE_DIR="$HOME/mkl-dnn-${MKLDNN_VERSION}/include"
+                              -DMKLDNN_LIBRARY="$HOME/mkl-dnn-${MKLDNN_VERSION}/lib/libmkldnn.so" .
                   build_command: make
                   branch_pattern: coverity_scan
           before_install:
@@ -64,29 +67,24 @@ matrix:
                     --version ${MKLDNN_VERSION} \
                     --download-dir ${HOME}/downloads \
                     --build-dir ${HOME}/build \
-                    --install-dir /usr/local \
+                    --install-dir ${HOME}/mkl-dnn-${MKLDNN_VERSION} \
                     --parallel ${MAKE_JOBS}
               - pip install --user chainer
-              - |
-                bash -ex ${TRAVIS_BUILD_DIR}/.travis/prepare-menoh-data.sh \
-                    --source-dir ${TRAVIS_BUILD_DIR} \
-                    --python-executable python
           script:
               #- if [ -f cov-int/build-log.txt ]; then cat cov-int/build-log.txt; fi
               # CMakeCache.txt generated for coverity_scan build hinders out-of-source build
               - if [ -f CMakeCache.txt ]; then rm CMakeCache.txt; fi
-              - if [ -d "build" ]; then mkdir -p build; fi
-              - cd build
-              - cmake -DENABLE_TEST=ON ..
-              - make
+              - |
+                bash -ex ${TRAVIS_BUILD_DIR}/.travis/build-menoh.sh \
+                    --source-dir ${TRAVIS_BUILD_DIR} \
+                    --mkldnn-dir ${HOME}/mkl-dnn-${MKLDNN_VERSION}
+              - |
+                bash -ex ${TRAVIS_BUILD_DIR}/.travis/prepare-menoh-data.sh \
+                    --source-dir ${TRAVIS_BUILD_DIR} \
+                    --python-executable python
+              - cd ${TRAVIS_BUILD_DIR}/build
               - ./test/menoh_test
               - ldd menoh/libmenoh.so
 
 script:
-    - |
-      echo "travis_fold:start:run-build.sh"
-      echo -e "\e[33;1mRunning .travis/run-build.sh\e[0m"
-
-      bash -ex ${TRAVIS_BUILD_DIR}/.travis/run-build.sh
-
-      echo "travis_fold:end:run-build.sh"
+    - bash -ex ${TRAVIS_BUILD_DIR}/.travis/run-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,10 @@ cache:
 #        echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 #      fi
 script:
-    - bash -ex ${TRAVIS_BUILD_DIR}/.travis/run-build.sh
+    - |
+      echo "travis_fold:start:run-build.sh"
+      echo -e "\e[33;1mRunning .travis/run-build.sh\e[0m"
+
+      bash -ex ${TRAVIS_BUILD_DIR}/.travis/run-build.sh
+
+      echo "travis_fold:end:run-build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ matrix:
         - os: linux
           env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6 LINK_STATIC=true
         # Use Travis directly instead of container to run static code analysis using Coverity
-        - os: linux
+        - if: branch = coverity_scan
+          os: linux
           env: RUN_COVERITY=true
           addons:
               apt:
@@ -69,22 +70,7 @@ matrix:
                     --build-dir ${HOME}/build \
                     --install-dir ${HOME}/mkl-dnn-${MKLDNN_VERSION} \
                     --parallel ${MAKE_JOBS}
-              - pip install --user chainer
-          script:
-              #- if [ -f cov-int/build-log.txt ]; then cat cov-int/build-log.txt; fi
-              # CMakeCache.txt generated for coverity_scan build hinders out-of-source build
-              - if [ -f CMakeCache.txt ]; then rm CMakeCache.txt; fi
-              - |
-                bash -ex ${TRAVIS_BUILD_DIR}/.travis/build-menoh.sh \
-                    --source-dir ${TRAVIS_BUILD_DIR} \
-                    --mkldnn-dir ${HOME}/mkl-dnn-${MKLDNN_VERSION}
-              - |
-                bash -ex ${TRAVIS_BUILD_DIR}/.travis/prepare-menoh-data.sh \
-                    --source-dir ${TRAVIS_BUILD_DIR} \
-                    --python-executable python
-              - cd ${TRAVIS_BUILD_DIR}/build
-              - ./test/menoh_test
-              - ldd menoh/libmenoh.so
+          script: true # skip build and test
 
 script:
     - bash -ex ${TRAVIS_BUILD_DIR}/.travis/run-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ matrix:
                   notification_email: menoh-oss@preferred.jp
                   build_command_prepend: >-
                       cov-configure --compiler /usr/bin/g++-7 --comptype g++ -- -march=native -fPIC -std=gnu++14 &&
-                          cmake
-                              -DMKLDNN_INCLUDE_DIR="$HOME/mkl-dnn-${MKLDNN_VERSION}/include"
-                              -DMKLDNN_LIBRARY="$HOME/mkl-dnn-${MKLDNN_VERSION}/lib/libmkldnn.so" .
+                      cmake
+                      -DMKLDNN_INCLUDE_DIR="$HOME/mkl-dnn-${MKLDNN_VERSION}/include"
+                      -DMKLDNN_LIBRARY="$HOME/mkl-dnn-${MKLDNN_VERSION}/lib/libmkldnn.so" .
                   build_command: make
                   branch_pattern: coverity_scan
           before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,124 +1,50 @@
 dist: trusty
 sudo: required
 language: cpp
+services:
+  - docker
 addons:
 matrix:
     include:
         - os: osx
+          env: PLATFORM=macosx-x86_64
         - os: osx
-          env: STATIC=1
+          env: PLATFORM=macosx-x86_64 LINK_STATIC=true
         - os: linux
-          addons:
-              apt:
-                  sources:
-                      - ubuntu-toolchain-r-test
-                      - sourceline: 'ppa:maarten-fonville/protobuf'
-                  packages:
-                      - gcc-7
-                      - g++-7
-                      - cmake-data
-                      - cmake
-                      - libopencv-dev
-                      - libprotobuf-dev
-                      - protobuf-compiler
-              coverity_scan:
-                  project:
-                      name: "pfnet-research/menoh"
-                      description: "Menoh: DNN inference library"
-                  notification_email: menoh-oss@preferred.jp
-                  build_command_prepend: >-
-                      cov-configure --compiler /usr/bin/g++-7 --comptype g++ -- -march=native -fPIC -std=gnu++14 &&
-                      cmake .
-                  build_command: make
-                  branch_pattern: coverity_scan
+          env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6
+#          addons:
+#              coverity_scan:
+#                  project:
+#                      name: "pfnet-research/menoh"
+#                      description: "Menoh: DNN inference library"
+#                  notification_email: menoh-oss@preferred.jp
+#                  build_command_prepend: >-
+#                      cov-configure --compiler /usr/bin/g++-7 --comptype g++ -- -march=native -fPIC -std=gnu++14 &&
+#                      cmake .
+#                  build_command: make
+#                  branch_pattern: coverity_scan
         - os: linux
-          env: STATIC=1
-          addons:
-              apt:
-                  sources:
-                      - ubuntu-toolchain-r-test
-                  packages:
-                      - gcc-7
-                      - g++-7
-                      - cmake-data
-                      - cmake
-                      - libopencv-dev
+          env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6 LINK_STATIC=true
+
 env:
     global:
+        - PROTOBUF_VERSION: 3.6.1
+        - MKLDNN_VERSION: 0.16
+        - MAKE_JOBS: 2
         # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
         #   via the "travis encrypt" command using the project repo's public key
-        - secure: "q1I4YsB5VcNaF9Unmm6T92ht9/KwOGbxZVCpXIp5XUVulpaZq7sTd3rL1v3r1mUCYaabkcy9N4UPQjJZsuOlU4jc8zPzPxPir7hOER5umlkfSMuc1RhmShT8cK9naznqv7FLSTIjTZIao85Lrgxgw0B6xzcWc0kSeJPJVAmS5kwmC/FCQS2MPQpyhfE5JjpUrePOT+lRTB6Psm5bWyEww8bPsatO2k5b8DDdmUJIxmuJ1UTCx5rj/ZcTJLWAsj8D7u9aUfCmOhV5+hqHBvJd/06FLt254SNmvzmVLW9CVU/aZvuTtRECgBYCVndR7NxWpRHo1SBKqgLu+cNOFoFyt++1V+FAbpxj9JMktZNyxWp22c/FvBBdHynOsxBxVFdGIzhcwhQMiHFLOK3pnyiByabtINhERqrszkbpztOepBE3o8PGpjOz8iIx1TtLgmWwAw5D6WXx8FeP5FMkJwpXckCMI5tX5wPoU8cpZIwPjCxG3Z+ojHw+80pQWCrMZnEDfcf9zskJNsmv/GbiWGEvI8xVG0gst5VmjaAXK7JhC0cKvPOEmCFRGY+BWdjD3dkYIIElUmBRfTRDpcDJV6j5r1xMv7QKRFDfAjnC33KLJo2aALZTrkRPveIP2h2jU13ZbemN8GKWwEWNzidmwtCbH4rpe80rFqASWkyfii7HrEI="
-before_install:
-    - |
-      if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-        echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
-      fi
-install:
-    - |
-      if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-        curl -LO https://github.com/pfnet-research/menoh/releases/download/v1.0.3/ubuntu1404_mkl-dnn_0.16-1_amd64.deb
-        curl -LO https://github.com/pfnet-research/menoh/releases/download/v1.0.3/ubuntu1404_mkl-dnn-dev_0.16-1_amd64.deb
-        sudo dpkg -i *.deb
-      fi
-    - |
-      if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-        brew update
-        brew upgrade python
-        export PATH=/usr/local/opt/python/libexec/bin:$PATH
-        brew install numpy || true
-        brew install opencv mkl-dnn
-        if [ -z "$STATIC" ]; then brew install protobuf; fi
-      else
-        pyenv local 3.6
-      fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CXX" = "g++" ]; then export CXX="g++-7" CC="gcc-7"; fi
-    - mkdir -p data
-    - pip install --user chainer
-    - python retrieve_data.py
-    - python gen_test_data.py
-before_script:
-    - |
-      echo 'Checking tools and libraries version:'
-      if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-        apt list --installed
-        ldconfig -p
-      fi
-      if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-        brew list --versions
-      fi
-      cmake --version
-      make --version
+#        - secure: "q1I4YsB5VcNaF9Unmm6T92ht9/KwOGbxZVCpXIp5XUVulpaZq7sTd3rL1v3r1mUCYaabkcy9N4UPQjJZsuOlU4jc8zPzPxPir7hOER5umlkfSMuc1RhmShT8cK9naznqv7FLSTIjTZIao85Lrgxgw0B6xzcWc0kSeJPJVAmS5kwmC/FCQS2MPQpyhfE5JjpUrePOT+lRTB6Psm5bWyEww8bPsatO2k5b8DDdmUJIxmuJ1UTCx5rj/ZcTJLWAsj8D7u9aUfCmOhV5+hqHBvJd/06FLt254SNmvzmVLW9CVU/aZvuTtRECgBYCVndR7NxWpRHo1SBKqgLu+cNOFoFyt++1V+FAbpxj9JMktZNyxWp22c/FvBBdHynOsxBxVFdGIzhcwhQMiHFLOK3pnyiByabtINhERqrszkbpztOepBE3o8PGpjOz8iIx1TtLgmWwAw5D6WXx8FeP5FMkJwpXckCMI5tX5wPoU8cpZIwPjCxG3Z+ojHw+80pQWCrMZnEDfcf9zskJNsmv/GbiWGEvI8xVG0gst5VmjaAXK7JhC0cKvPOEmCFRGY+BWdjD3dkYIIElUmBRfTRDpcDJV6j5r1xMv7QKRFDfAjnC33KLJo2aALZTrkRPveIP2h2jU13ZbemN8GKWwEWNzidmwtCbH4rpe80rFqASWkyfii7HrEI="
+
+cache:
+  directories:
+    - ${HOME}/downloads
+    - ${HOME}/build/protobuf-${PROTOBUF_VERSION}
+    - ${HOME}/build/mkl-dnn-${MKLDNN_VERSION}
+
+#before_install:
+#    - |
+#      if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+#        echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+#      fi
 script:
-    #- if [ -f cov-int/build-log.txt ]; then cat cov-int/build-log.txt; fi
-    # CMakeCache.txt generated for coverity_scan build hinders out-of-source build
-    - if [ -f CMakeCache.txt ]; then rm CMakeCache.txt; fi
-    - |
-      if [ -n "$STATIC" ]; then
-        if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-          STATIC_OPTION="-DLINK_STATIC_LIBPROTOBUF=ON"
-        else
-          STATIC_OPTION="-DLINK_STATIC_LIBPROTOBUF=ON -DLINK_STATIC_LIBSTDCXX=ON -DLINK_STATIC_LIBGCC=ON"
-        fi
-      else
-        STATIC_OPTION=""
-      fi
-    - mkdir build
-    - cd build
-    - |
-      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-        cmake -DENABLE_TEST=ON \
-        $STATIC_OPTION \
-        ..
-      else
-        cmake -DENABLE_TEST=ON \
-        $STATIC_OPTION \
-        ..
-      fi
-    - make
-    - ./test/menoh_test
-    - |
-      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-        otool -L menoh/libmenoh.dylib
-      else
-        ldd menoh/libmenoh.so
-      fi
+    - bash -ex ${TRAVIS_BUILD_DIR}/.travis/run-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,14 +53,10 @@ matrix:
                       description: "Menoh: DNN inference library"
                   notification_email: menoh-oss@preferred.jp
                   build_command_prepend: >-
-                      cov-configure --compiler /usr/bin/g++-7 --comptype g++ -- -march=native -fPIC -std=gnu++14 &&
-                      cmake
-                      -DMKLDNN_INCLUDE_DIR="$HOME/mkl-dnn-${MKLDNN_VERSION}/include"
-                      -DMKLDNN_LIBRARY="$HOME/mkl-dnn-${MKLDNN_VERSION}/lib/libmkldnn.so" .
+                      cov-configure --compiler g++-7 --comptype g++ --template &&
+                      cmake -DMKLDNN_INCLUDE_DIR="$HOME/mkl-dnn-${MKLDNN_VERSION}/include" -DMKLDNN_LIBRARY="$HOME/mkl-dnn-${MKLDNN_VERSION}/lib/libmkldnn.so" .
                   build_command: make
                   branch_pattern: coverity_scan
-          before_install:
-              - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
           install:
               - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CXX" = "g++" ]; then export CXX="g++-7" CC="gcc-7"; fi
               - |

--- a/.travis/README.md
+++ b/.travis/README.md
@@ -18,7 +18,7 @@ Currently it uses [okapies/buildenv](https://hub.docker.com/r/okapies/buildenv/)
     - It runs a Docker container before calling `build.sh` if it is in the Linux-based platforms
     - You can access `${HOME}` (`/home/travis`) directory from the container transparently because it maps `${HOME}` in the Travis environment to container's `/home/travis`
 2. `build.sh`
-    - In Linux, the build workflow is run *in the container*. All commands are run by `docker_exec` and `docker_exec_cmd` functions
+    - In Linux, the build workflow is run *in the container*. All commands are run by `docker_exec` and `docker_exec_script` functions
     - Install the prerequisites
     - Run a build
     - Run a test

--- a/.travis/README.md
+++ b/.travis/README.md
@@ -14,12 +14,13 @@ Currently it uses [okapies/buildenv](https://hub.docker.com/r/okapies/buildenv/)
 ## Architecture
 `.travis.yml` -> `run-build.sh` -> `build.sh` -> `install-*.sh` & `build-menoh.sh`
 
-1. `run-build.sh` calls `build.sh` at once for running the actual build workflow
+1. `run-build.sh` just calls a platform's `build.sh` for running the actual build workflow
 2. `build.sh`
-    - In Linux-based platforms, build workflow is run *in the container*
-        - It runs a Docker container before executing the workflow
-        - All commands are run via `docker_exec` and `docker_exec_script` functions
-        - You can access `${HOME}` (`/home/travis`) directory from the container transparently because it maps `${HOME}` in the Travis environment to container's `/home/travis`
+    - For Linux-based platforms, the build workflow is executed *in the container*
+        - `build.sh` runs a Docker container at startup before executing the workflow
+        - All commands are run via `docker_exec` and `docker_exec_script` functions (defined in `init-build-linux.sh`)
+        - You can access `${HOME}` (`/home/travis`) directory from inside the container transparently because it maps `/home/travis` in the Travis environment to container's `/home/travis`
+    - For macOS (OSX), the build workflow is executed on the Travis' VM
     - Install the prerequisites
     - Run a build
     - Run a test

--- a/.travis/README.md
+++ b/.travis/README.md
@@ -1,7 +1,7 @@
 # Build scripts for Travis
 
 ## Prerequisites
-It requires a container image with the following softwares:
+Linux-based platforms requires a container image with the following softwares:
 
 - GCC 5.2 or later
 - CMake 3.1 or later
@@ -14,10 +14,11 @@ Currently it uses [okapies/buildenv](https://hub.docker.com/r/okapies/buildenv/)
 ## Architecture
 `.travis.yml` -> `run-build.sh` -> `build.sh` -> `install-*.sh` & `build-menoh.sh`
 
-1. `run-build.sh` starts a Docker container for building the project
+1. `run-build.sh` calls `build.sh` at once for running the actual build workflow
+    - It runs a Docker container before calling `build.sh` if it is in the Linux-based platforms
     - You can access `${HOME}` (`/home/travis`) directory from the container transparently because it maps `${HOME}` in the Travis environment to container's `/home/travis`
-2. `build.sh` runs a build workflow *in the container*
-    - (All commands are run by `docker_exec` and `docker_exec_cmd` functions)
+2. `build.sh`
+    - In Linux, the build workflow is run *in the container*. All commands are run by `docker_exec` and `docker_exec_cmd` functions
     - Install the prerequisites
     - Run a build
     - Run a test

--- a/.travis/README.md
+++ b/.travis/README.md
@@ -15,10 +15,11 @@ Currently it uses [okapies/buildenv](https://hub.docker.com/r/okapies/buildenv/)
 `.travis.yml` -> `run-build.sh` -> `build.sh` -> `install-*.sh` & `build-menoh.sh`
 
 1. `run-build.sh` calls `build.sh` at once for running the actual build workflow
-    - It runs a Docker container before calling `build.sh` if it is in the Linux-based platforms
-    - You can access `${HOME}` (`/home/travis`) directory from the container transparently because it maps `${HOME}` in the Travis environment to container's `/home/travis`
 2. `build.sh`
-    - In Linux, the build workflow is run *in the container*. All commands are run by `docker_exec` and `docker_exec_script` functions
+    - In Linux-based platforms, build workflow is run *in the container*
+        - It runs a Docker container before executing the workflow
+        - All commands are run via `docker_exec` and `docker_exec_script` functions
+        - You can access `${HOME}` (`/home/travis`) directory from the container transparently because it maps `${HOME}` in the Travis environment to container's `/home/travis`
     - Install the prerequisites
     - Run a build
     - Run a test

--- a/.travis/README.md
+++ b/.travis/README.md
@@ -1,0 +1,50 @@
+# Build scripts for Travis
+
+## Prerequisites
+It requires a container image with the following softwares:
+
+- GCC 5.2 or later
+- CMake 3.1 or later
+- Python 3.6
+- pip
+- OpenCV 2.4 or later
+
+Currently it uses [okapies/buildenv](https://hub.docker.com/r/okapies/buildenv/) image for linux-x86_64 platform.
+
+## Architecture
+`.travis.yml` -> `run-build.sh` -> `build.sh` -> `install-*.sh` & `build-menoh.sh`
+
+1. `run-build.sh` starts a Docker container for building the project
+    - You can access `${HOME}` (`/home/travis`) directory from the container transparently because it maps `${HOME}` in the Travis environment to container's `/home/travis`
+2. `build.sh` runs a build workflow *in the container*
+    - (All commands are run by `docker_exec` and `docker_exec_cmd` functions)
+    - Install the prerequisites
+    - Run a build
+    - Run a test
+3. Release and clean up
+
+## Directory
+- `/home/travis` (= `${HOME}`)
+    - `/downloads` (cache)
+    - `/build`
+        - `/protobuf-<ver>` (cache)
+        - `/mkl-dnn-<ver>` (cache)
+        - `/<user>/<repo>` (= `${TRAVIS_BUILD_DIR}`)
+            - `/menoh`
+            - `/test`
+            - `/cmake`
+            - `CMakeLists.txt`
+            - ...
+            - `/build`
+                - `/menoh`
+                - `/test`
+                - ...
+
+## Cache
+```yaml
+cache:
+  directories:
+    - ${HOME}/downloads
+    - ${HOME}/build/protobuf-${PROTOBUF_VERSION}
+    - ${HOME}/build/mkl-dnn-${MKLDNN_VERSION}
+```

--- a/.travis/build-menoh.sh
+++ b/.travis/build-menoh.sh
@@ -47,7 +47,7 @@ test -n "${ARG_LINK_STATIC_LIBPROTOBUF}" || ARG_LINK_STATIC_LIBPROTOBUF='OFF'
 
 echo -e "\e[33;1mBuilding Menoh\e[0m"
 
-cd ${ARG_SOURCE_DIR}/menoh
+cd ${ARG_SOURCE_DIR}
 [ -d "build" ] || mkdir -p build
 
 cd build

--- a/.travis/build-menoh.sh
+++ b/.travis/build-menoh.sh
@@ -39,7 +39,7 @@ while [[ $# != 0 ]]; do
 done
 
 # validate the arguments
-test -n "${ARG_SOURCE_DIR}" || { echo "--source-dir is not specified"; exit 1; }
+test -n "${ARG_SOURCE_DIR}" || { echo "--source-dir is not specified" 1>&2; exit 1; }
 
 test -n "${ARG_LINK_STATIC_LIBGCC}" || ARG_LINK_STATIC_LIBGCC='OFF'
 test -n "${ARG_LINK_STATIC_LIBSTDCXX}" || ARG_LINK_STATIC_LIBSTDCXX='OFF'

--- a/.travis/build-menoh.sh
+++ b/.travis/build-menoh.sh
@@ -15,6 +15,10 @@ while [[ $# != 0 ]]; do
             ARG_INSTALL_DIR="$2"
             shift 2
             ;;
+        --mkldnn-dir)
+            ARG_MKLDNN_DIR="$2"
+            shift 2
+            ;;
         --link-static-libgcc)
             ARG_LINK_STATIC_LIBGCC="$2"
             shift 2
@@ -52,11 +56,17 @@ cd ${ARG_SOURCE_DIR}
 
 cd build
 if [ -n "${ARG_INSTALL_DIR}" ]; then
-    CMAKE_INSTALL_PREFIX="-DCMAKE_INSTALL_PREFIX=${ARG_INSTALL_DIR}"
+    OPT_CMAKE_INSTALL_PREFIX=-DCMAKE_INSTALL_PREFIX=${ARG_INSTALL_DIR}
+fi
+if [ -n "${ARG_MKLDNN_DIR}" ]; then
+    OPT_MKLDNN_INCLUDE_DIR=-DMKLDNN_INCLUDE_DIR=${ARG_MKLDNN_DIR}/include
+    OPT_MKLDNN_LIBRARY=-DMKLDNN_LIBRARY=${ARG_MKLDNN_DIR}/lib/libmkldnn.so
 fi
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
-    ${CMAKE_INSTALL_PREFIX} \
+    ${OPT_CMAKE_INSTALL_PREFIX} \
+    ${OPT_MKLDNN_INCLUDE_DIR} \
+    ${OPT_MKLDNN_LIBRARY} \
     -DLINK_STATIC_LIBGCC=${ARG_LINK_STATIC_LIBGCC} \
     -DLINK_STATIC_LIBSTDCXX=${ARG_LINK_STATIC_LIBSTDCXX} \
     -DLINK_STATIC_LIBPROTOBUF=${ARG_LINK_STATIC_LIBPROTOBUF} \

--- a/.travis/build-menoh.sh
+++ b/.travis/build-menoh.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# retrieve arguments
+while [[ $# != 0 ]]; do
+    case $1 in
+        --)
+            shift
+            break
+            ;;
+        --source-dir)
+            ARG_SOURCE_DIR="$2"
+            shift 2
+            ;;
+        --install-dir)
+            ARG_INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --link-static-libgcc)
+            ARG_LINK_STATIC_LIBGCC="$2"
+            shift 2
+            ;;
+        --link-static-libstdcxx)
+            ARG_LINK_STATIC_LIBSTDCXX="$2"
+            shift 2
+            ;;
+        --link-static-libprotobuf)
+            ARG_LINK_STATIC_LIBPROTOBUF="$2"
+            shift 2
+            ;;
+        -*)
+            err Unknown option \"$1\"
+            exit
+            ;;
+        *)
+            break
+            ;;
+
+    esac
+done
+
+# validate the arguments
+test -n "${ARG_SOURCE_DIR}" || { echo "--source-dir is not specified"; exit 1; }
+
+test -n "${ARG_LINK_STATIC_LIBGCC}" || ARG_LINK_STATIC_LIBGCC='OFF'
+test -n "${ARG_LINK_STATIC_LIBSTDCXX}" || ARG_LINK_STATIC_LIBSTDCXX='OFF'
+test -n "${ARG_LINK_STATIC_LIBPROTOBUF}" || ARG_LINK_STATIC_LIBPROTOBUF='OFF'
+
+echo -e "\e[33;1mBuilding Menoh\e[0m"
+
+cd ${ARG_SOURCE_DIR}/menoh
+[ -d "build" ] || mkdir -p build
+
+cd build
+if [ -n "${ARG_INSTALL_DIR}" ]; then
+    CMAKE_INSTALL_PREFIX="-DCMAKE_INSTALL_PREFIX=${ARG_INSTALL_DIR}"
+fi
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    ${CMAKE_INSTALL_PREFIX} \
+    -DLINK_STATIC_LIBGCC=${ARG_LINK_STATIC_LIBGCC} \
+    -DLINK_STATIC_LIBSTDCXX=${ARG_LINK_STATIC_LIBSTDCXX} \
+    -DLINK_STATIC_LIBPROTOBUF=${ARG_LINK_STATIC_LIBPROTOBUF} \
+    -DENABLE_TEST=ON \
+    ..
+
+make

--- a/.travis/init-build-linux.sh
+++ b/.travis/init-build-linux.sh
@@ -1,8 +1,8 @@
 # check if variables are set
-test -n "${DOCKER_CONTAINER_ID}" || { echo "DOCKER_CONTAINER_ID does not exist" 1>&2; exit 1; }
-test -n "${PROTOBUF_VERSION}" || { echo "PROTOBUF_VERSION does not exist" 1>&2; exit 1; }
-test -n "${MKLDNN_VERSION}" || { echo "MKLDNN_VERSION does not exist" 1>&2; exit 1; }
-test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS does not exist" 1>&2; exit 1; }
+test -n "${DOCKER_CONTAINER_ID}" || { echo "DOCKER_CONTAINER_ID can't be empty" 1>&2; exit 1; }
+test -n "${PROTOBUF_VERSION}" || { echo "PROTOBUF_VERSION can't be empty" 1>&2; exit 1; }
+test -n "${MKLDNN_VERSION}" || { echo "MKLDNN_VERSION can't be empty" 1>&2; exit 1; }
+test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS can't be empty" 1>&2; exit 1; }
 
 test -n "${LINK_STATIC}" || LINK_STATIC=false
 
@@ -13,17 +13,22 @@ export PROJ_DIR=${TRAVIS_BUILD_DIR} # = ${HOME}/build/${TRAVIS_REPO_SLUG}
 export PROTOBUF_INSTALL_DIR=/usr/local
 export MKLDNN_INSTALL_DIR=/usr/local
 
-# define shared functions for Linux-based platforms
+## define shared functions for Linux-based platforms
+
+# Run the specified string as command in the container
 function docker_exec() {
     docker exec -it ${DOCKER_CONTAINER_ID} /bin/bash -xec "$1"
+    return $?
 }
 
-function docker_exec_cmd() {
+# Run the specified shell script in the container
+function docker_exec_script() {
     docker exec -it ${DOCKER_CONTAINER_ID} /bin/bash -xe $@
+    return $?
 }
 
 function install_protobuf() {
-    docker_exec_cmd \
+    docker_exec_script \
         ${PROJ_DIR}/.travis/install-protobuf.sh \
             --version ${PROTOBUF_VERSION} \
             --download-dir ${WORK_DIR}/downloads \
@@ -33,7 +38,7 @@ function install_protobuf() {
 }
 
 function install_mkldnn() {
-    docker_exec_cmd \
+    docker_exec_script \
         ${PROJ_DIR}/.travis/install-mkldnn.sh \
             --version ${MKLDNN_VERSION} \
             --download-dir ${WORK_DIR}/downloads \
@@ -43,7 +48,7 @@ function install_mkldnn() {
 }
 
 function prepare_menoh_data() {
-    docker_exec_cmd \
+    docker_exec_script \
         ${PROJ_DIR}/.travis/prepare-menoh-data.sh \
             --source-dir ${PROJ_DIR} \
             --python-executable python3
@@ -51,11 +56,11 @@ function prepare_menoh_data() {
 
 function build_menoh() {
     if [ "${LINK_STATIC}" != "true" ]; then
-        docker_exec_cmd \
+        docker_exec_script \
             ${PROJ_DIR}/.travis/build-menoh.sh \
                 --source-dir ${PROJ_DIR}
     else
-        docker_exec_cmd \
+        docker_exec_script \
             ${PROJ_DIR}/.travis/build-menoh.sh \
                 --source-dir ${PROJ_DIR} \
                 --link-static-libgcc ON \

--- a/.travis/init-build-linux.sh
+++ b/.travis/init-build-linux.sh
@@ -1,5 +1,4 @@
 # check if variables are set
-test -n "${DOCKER_CONTAINER_ID}" || { echo "DOCKER_CONTAINER_ID can't be empty" 1>&2; exit 1; }
 test -n "${PROTOBUF_VERSION}" || { echo "PROTOBUF_VERSION can't be empty" 1>&2; exit 1; }
 test -n "${MKLDNN_VERSION}" || { echo "MKLDNN_VERSION can't be empty" 1>&2; exit 1; }
 test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS can't be empty" 1>&2; exit 1; }
@@ -13,17 +12,25 @@ export PROJ_DIR=${TRAVIS_BUILD_DIR} # = ${HOME}/build/${TRAVIS_REPO_SLUG}
 export PROTOBUF_INSTALL_DIR=/usr/local
 export MKLDNN_INSTALL_DIR=/usr/local
 
+# Run a docker container and map Travis's $HOME to the container's $HOME
+# $HOME:$HOME = /home/travis                     : /home/travis
+#               /home/travis/build               : /home/travis/build
+#               /home/travis/build/<user>/<repo> : /home/travis/build/<user>/<repo> (= ${TRAVIS_BUILD_DIR})
+SHARED_SCRIPT_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
+source ${SHARED_SCRIPT_DIR}/run-container.sh --image ${BUILDENV_IMAGE} --work-dir ${WORK_DIR}
+test -n "${BUILDENV_CONTAINER_ID}" || { echo "BUILDENV_CONTAINER_ID can't be empty" 1>&2; exit 1; }
+
 ## define shared functions for Linux-based platforms
 
 # Run the specified string as command in the container
 function docker_exec() {
-    docker exec -it ${DOCKER_CONTAINER_ID} /bin/bash -xec "$1"
+    docker exec -it ${BUILDENV_CONTAINER_ID} /bin/bash -xec "$1"
     return $?
 }
 
 # Run the specified shell script in the container
 function docker_exec_script() {
-    docker exec -it ${DOCKER_CONTAINER_ID} /bin/bash -xe $@
+    docker exec -it ${BUILDENV_CONTAINER_ID} /bin/bash -xe $@
     return $?
 }
 

--- a/.travis/init-build-linux.sh
+++ b/.travis/init-build-linux.sh
@@ -45,7 +45,7 @@ function install_mkldnn() {
 function prepare_menoh_data() {
     echo -e "\e[33;1mPreparing data/ for Menoh\e[0m"
     docker_exec "$(cat << EOS
-        cd ${PROJ_DIR}/menoh && \
+        cd ${PROJ_DIR} && \
         ([ -d "data" ] || mkdir -p data) && \
         python3 retrieve_data.py && \
         python3 gen_test_data.py
@@ -71,9 +71,9 @@ function build_menoh() {
 }
 
 function test_menoh() {
-    docker_exec "cd ${PROJ_DIR}/menoh/build && ./test/menoh_test"
+    docker_exec "cd ${PROJ_DIR}/build/menoh && ./test/menoh_test"
 }
 
 function check_menoh_artifact() {
-    ldd ${PROJ_DIR}/menoh/build/menoh/libmenoh.so
+    ldd ${PROJ_DIR}/build/menoh/libmenoh.so
 }

--- a/.travis/init-build-linux.sh
+++ b/.travis/init-build-linux.sh
@@ -1,0 +1,79 @@
+# check if variables are set
+test -n "${DOCKER_CONTAINER_ID}" || { echo "DOCKER_CONTAINER_ID does not exist"; exit 1; }
+test -n "${PROTOBUF_VERSION}" || { echo "PROTOBUF_VERSION does not exist"; exit 1; }
+test -n "${MKLDNN_VERSION}" || { echo "MKLDNN_VERSION does not exist"; exit 1; }
+test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS does not exist"; exit 1; }
+
+test -n "${LINK_STATIC}" || LINK_STATIC=false
+
+# TODO: make them configurable for outside Travis
+export WORK_DIR=${HOME}
+export PROJ_DIR=${TRAVIS_BUILD_DIR} # = ${HOME}/build/${TRAVIS_REPO_SLUG}
+
+export PROTOBUF_INSTALL_DIR=/usr/local
+export MKLDNN_INSTALL_DIR=/usr/local
+
+# define shared functions for Linux-based platforms
+function docker_exec() {
+    docker exec -it ${DOCKER_CONTAINER_ID} /bin/bash -xec "$1"
+}
+
+function docker_exec_cmd() {
+    docker exec -it ${DOCKER_CONTAINER_ID} /bin/bash -xe $@
+}
+
+function install_protobuf() {
+    docker_exec_cmd \
+        ${PROJ_DIR}/.travis/install-protobuf.sh \
+            --version ${PROTOBUF_VERSION} \
+            --download-dir ${WORK_DIR}/downloads \
+            --build-dir ${WORK_DIR}/build \
+            --install-dir ${PROTOBUF_INSTALL_DIR} \
+            --parallel ${MAKE_JOBS}
+}
+
+function install_mkldnn() {
+    docker_exec_cmd \
+        ${PROJ_DIR}/.travis/install-mkldnn.sh \
+            --version ${MKLDNN_VERSION} \
+            --download-dir ${WORK_DIR}/downloads \
+            --build-dir ${WORK_DIR}/build \
+            --install-dir ${MKLDNN_INSTALL_DIR} \
+            --parallel ${MAKE_JOBS}
+}
+
+function prepare_menoh_data() {
+    echo -e "\e[33;1mPreparing data/ for Menoh\e[0m"
+    docker_exec "$(cat << EOS
+        cd ${PROJ_DIR}/menoh && \
+        ([ -d "data" ] || mkdir -p data) && \
+        python3 retrieve_data.py && \
+        python3 gen_test_data.py
+EOS
+)"
+}
+
+function build_menoh() {
+    # CMakeCache.txt generated for coverity_scan build hinders out-of-source build
+    docker_exec "if [ -f \"CMakeCache.txt\" ]; then cd ${PROJ_DIR} && rm CMakeCache.txt; fi"
+    if [ "${LINK_STATIC}" != "true" ]; then
+        docker_exec_cmd \
+            ${PROJ_DIR}/.travis/build-menoh.sh \
+                --source-dir ${PROJ_DIR}
+    else
+        docker_exec_cmd \
+            ${PROJ_DIR}/.travis/build-menoh.sh \
+                --source-dir ${PROJ_DIR} \
+                --link-static-libgcc ON \
+                --link-static-libstdcxx ON \
+                --link-static-libprotobuf ON
+    fi
+}
+
+function test_menoh() {
+    docker_exec "cd ${PROJ_DIR}/menoh/build && ./test/menoh_test"
+}
+
+function check_menoh_artifact() {
+    ldd ${PROJ_DIR}/menoh/build/menoh/libmenoh.so
+}

--- a/.travis/init-build-linux.sh
+++ b/.travis/init-build-linux.sh
@@ -1,8 +1,8 @@
 # check if variables are set
-test -n "${DOCKER_CONTAINER_ID}" || { echo "DOCKER_CONTAINER_ID does not exist"; exit 1; }
-test -n "${PROTOBUF_VERSION}" || { echo "PROTOBUF_VERSION does not exist"; exit 1; }
-test -n "${MKLDNN_VERSION}" || { echo "MKLDNN_VERSION does not exist"; exit 1; }
-test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS does not exist"; exit 1; }
+test -n "${DOCKER_CONTAINER_ID}" || { echo "DOCKER_CONTAINER_ID does not exist" 1>&2; exit 1; }
+test -n "${PROTOBUF_VERSION}" || { echo "PROTOBUF_VERSION does not exist" 1>&2; exit 1; }
+test -n "${MKLDNN_VERSION}" || { echo "MKLDNN_VERSION does not exist" 1>&2; exit 1; }
+test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS does not exist" 1>&2; exit 1; }
 
 test -n "${LINK_STATIC}" || LINK_STATIC=false
 
@@ -43,19 +43,13 @@ function install_mkldnn() {
 }
 
 function prepare_menoh_data() {
-    echo -e "\e[33;1mPreparing data/ for Menoh\e[0m"
-    docker_exec "$(cat << EOS
-        cd ${PROJ_DIR} && \
-        ([ -d "data" ] || mkdir -p data) && \
-        python3 retrieve_data.py && \
-        python3 gen_test_data.py
-EOS
-)"
+    docker_exec_cmd \
+        ${PROJ_DIR}/.travis/prepare-menoh-data.sh \
+            --source-dir ${PROJ_DIR} \
+            --python-executable python3
 }
 
 function build_menoh() {
-    # CMakeCache.txt generated for coverity_scan build hinders out-of-source build
-    docker_exec "if [ -f \"CMakeCache.txt\" ]; then cd ${PROJ_DIR} && rm CMakeCache.txt; fi"
     if [ "${LINK_STATIC}" != "true" ]; then
         docker_exec_cmd \
             ${PROJ_DIR}/.travis/build-menoh.sh \

--- a/.travis/init-build-linux.sh
+++ b/.travis/init-build-linux.sh
@@ -71,7 +71,7 @@ function build_menoh() {
 }
 
 function test_menoh() {
-    docker_exec "cd ${PROJ_DIR}/build/menoh && ./test/menoh_test"
+    docker_exec "cd ${PROJ_DIR}/build && ./test/menoh_test"
 }
 
 function check_menoh_artifact() {

--- a/.travis/init-build-linux.sh
+++ b/.travis/init-build-linux.sh
@@ -81,5 +81,5 @@ function test_menoh() {
 }
 
 function check_menoh_artifact() {
-    ldd ${PROJ_DIR}/build/menoh/libmenoh.so
+    docker_exec "ldd ${PROJ_DIR}/build/menoh/libmenoh.so"
 }

--- a/.travis/init-build-osx.sh
+++ b/.travis/init-build-osx.sh
@@ -1,18 +1,14 @@
 # check if variables are set
-test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS does not exist"; exit 1; }
+test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS does not exist" 1>&2; exit 1; }
 
 # TODO: make them configurable for outside Travis
 export WORK_DIR=${HOME}
 export PROJ_DIR=${TRAVIS_BUILD_DIR} # = ${HOME}/build/${TRAVIS_REPO_SLUG}
 
 function prepare_menoh_data() {
-    echo -e "\e[33;1mPreparing data/ for Menoh\e[0m"
-
-    cd ${PROJ_DIR}
-    [ -d "data" ] || mkdir -p data
-
-    python retrieve_data.py
-    python gen_test_data.py
+    bash -ex ${PROJ_DIR}/.travis/prepare-menoh-data.sh \
+        --source-dir ${PROJ_DIR} \
+        --python-executable python
 }
 
 function build_menoh() {

--- a/.travis/init-build-osx.sh
+++ b/.travis/init-build-osx.sh
@@ -1,0 +1,36 @@
+# check if variables are set
+test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS does not exist"; exit 1; }
+
+# TODO: make them configurable for outside Travis
+export WORK_DIR=${HOME}
+export PROJ_DIR=${TRAVIS_BUILD_DIR} # = ${HOME}/build/${TRAVIS_REPO_SLUG}
+
+function prepare_menoh_data() {
+    echo -e "\e[33;1mPreparing data/ for Menoh\e[0m"
+
+    cd ${PROJ_DIR}/menoh
+    [ -d "data" ] || mkdir -p data
+
+    python retrieve_data.py
+    python gen_test_data.py
+}
+
+function build_menoh() {
+    if [ "${LINK_STATIC}" != "true" ]; then
+        ${PROJ_DIR}/.travis/build-menoh.sh \
+            --source-dir ${PROJ_DIR}
+    else
+    	# Does not set --link-static-libgcc and --link-static-libstdcxx in macOS
+        ${PROJ_DIR}/.travis/build-menoh.sh \
+            --source-dir ${PROJ_DIR} \
+            --link-static-libprotobuf ON
+    fi
+}
+
+function test_menoh() {
+    cd ${PROJ_DIR}/menoh/build && ./test/menoh_test
+}
+
+function check_menoh_artifact() {
+    otool -L ${PROJ_DIR}/menoh/build/menoh/libmenoh.dylib
+}

--- a/.travis/init-build-osx.sh
+++ b/.travis/init-build-osx.sh
@@ -5,6 +5,8 @@ test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS can't be empty" 1>&2; exit 1; }
 export WORK_DIR=${HOME}
 export PROJ_DIR=${TRAVIS_BUILD_DIR} # = ${HOME}/build/${TRAVIS_REPO_SLUG}
 
+## define shared functions for macOS (OSX) platforms
+
 function prepare_menoh_data() {
     bash -ex ${PROJ_DIR}/.travis/prepare-menoh-data.sh \
         --source-dir ${PROJ_DIR} \
@@ -16,7 +18,7 @@ function build_menoh() {
         bash -ex ${PROJ_DIR}/.travis/build-menoh.sh \
             --source-dir ${PROJ_DIR}
     else
-    	# Does not set --link-static-libgcc and --link-static-libstdcxx in macOS
+        # Does not set --link-static-libgcc and --link-static-libstdcxx in macOS
         bash -ex ${PROJ_DIR}/.travis/build-menoh.sh \
             --source-dir ${PROJ_DIR} \
             --link-static-libprotobuf ON

--- a/.travis/init-build-osx.sh
+++ b/.travis/init-build-osx.sh
@@ -1,5 +1,5 @@
 # check if variables are set
-test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS does not exist" 1>&2; exit 1; }
+test -n "${MAKE_JOBS}" || { echo "MAKE_JOBS can't be empty" 1>&2; exit 1; }
 
 # TODO: make them configurable for outside Travis
 export WORK_DIR=${HOME}
@@ -24,7 +24,8 @@ function build_menoh() {
 }
 
 function test_menoh() {
-    cd ${PROJ_DIR}/build && ./test/menoh_test
+    cd ${PROJ_DIR}/build
+    ./test/menoh_test
 }
 
 function check_menoh_artifact() {

--- a/.travis/init-build-osx.sh
+++ b/.travis/init-build-osx.sh
@@ -8,7 +8,7 @@ export PROJ_DIR=${TRAVIS_BUILD_DIR} # = ${HOME}/build/${TRAVIS_REPO_SLUG}
 function prepare_menoh_data() {
     echo -e "\e[33;1mPreparing data/ for Menoh\e[0m"
 
-    cd ${PROJ_DIR}/menoh
+    cd ${PROJ_DIR}
     [ -d "data" ] || mkdir -p data
 
     python retrieve_data.py
@@ -17,20 +17,20 @@ function prepare_menoh_data() {
 
 function build_menoh() {
     if [ "${LINK_STATIC}" != "true" ]; then
-        ${PROJ_DIR}/.travis/build-menoh.sh \
+        bash -ex ${PROJ_DIR}/.travis/build-menoh.sh \
             --source-dir ${PROJ_DIR}
     else
     	# Does not set --link-static-libgcc and --link-static-libstdcxx in macOS
-        ${PROJ_DIR}/.travis/build-menoh.sh \
+        bash -ex ${PROJ_DIR}/.travis/build-menoh.sh \
             --source-dir ${PROJ_DIR} \
             --link-static-libprotobuf ON
     fi
 }
 
 function test_menoh() {
-    cd ${PROJ_DIR}/menoh/build && ./test/menoh_test
+    cd ${PROJ_DIR}/build/menoh && ./test/menoh_test
 }
 
 function check_menoh_artifact() {
-    otool -L ${PROJ_DIR}/menoh/build/menoh/libmenoh.dylib
+    otool -L ${PROJ_DIR}/build/menoh/libmenoh.dylib
 }

--- a/.travis/init-build-osx.sh
+++ b/.travis/init-build-osx.sh
@@ -28,7 +28,7 @@ function build_menoh() {
 }
 
 function test_menoh() {
-    cd ${PROJ_DIR}/build/menoh && ./test/menoh_test
+    cd ${PROJ_DIR}/build && ./test/menoh_test
 }
 
 function check_menoh_artifact() {

--- a/.travis/install-mkldnn.sh
+++ b/.travis/install-mkldnn.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# retrieve arguments
+while [[ $# != 0 ]]; do
+    case $1 in
+        --)
+            shift
+            break
+            ;;
+        --version)
+            ARG_VERSION="$2"
+            shift 2
+            ;;
+        --download-dir)
+            ARG_DOWNLOAD_DIR="$2"
+            shift 2
+            ;;
+        --build-dir)
+            ARG_BUILD_DIR="$2"
+            shift 2
+            ;;
+        --install-dir)
+            ARG_INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --parallel)
+            ARG_PARALLEL="$2"
+            shift 2
+            ;;
+        -*)
+            err Unknown option \"$1\"
+            exit
+            ;;
+        *)
+            break
+            ;;
+
+    esac
+done
+
+# validate the arguments
+test -n "${ARG_VERSION}" || { echo "--version is not specified"; exit 1; }
+test -n "${ARG_DOWNLOAD_DIR}" || { echo "--download-dir is not specified"; exit 1; }
+test -n "${ARG_BUILD_DIR}" || { echo "--build-dir is not specified"; exit 1; }
+test -n "${ARG_INSTALL_DIR}" || { echo "--install-dir is not specified"; exit 1; }
+test -n "${ARG_PARALLEL}" || ARG_PARALLEL=1
+
+# download (if it isn't cached)
+if [ ! -e "${ARG_BUILD_DIR}/mkl-dnn-${ARG_VERSION}/LICENSE" ]; then
+    echo -e "\e[33;1mDownloading libmkldnn\e[0m"
+
+    [ -d "${ARG_DOWNLOAD_DIR}" ] || mkdir -p ${ARG_DOWNLOAD_DIR}
+
+    cd ${ARG_DOWNLOAD_DIR}
+    if [ ! -e "mkl-dnn-${ARG_VERSION}.tar.gz" ]; then
+        download_url="https://github.com/intel/mkl-dnn/archive/v${ARG_VERSION}.tar.gz"
+        wget -O mkl-dnn-${ARG_VERSION}.tar.gz ${download_url}
+    fi
+    tar -zxf mkl-dnn-${ARG_VERSION}.tar.gz -C ${ARG_BUILD_DIR}
+
+    echo -e "\e[32;1mlibmkldnn was successfully downloaded.\e[0m"
+else
+    echo -e "\e[32;1mlibmkldnn has been downloaded.\e[0m"
+fi
+
+# build (if it isn't cached)
+if [ ! -e "${ARG_BUILD_DIR}/mkl-dnn-${ARG_VERSION}/build/src/libmkldnn.so" ]; then
+    echo -e "\e[33;1mBuilding libmkldnn\e[0m"
+
+    cd ${ARG_BUILD_DIR}/mkl-dnn-${ARG_VERSION}/scripts
+    ./prepare_mkl.sh
+
+    cd ${ARG_BUILD_DIR}/mkl-dnn-${ARG_VERSION}
+    [ -d "build" ] || mkdir -p build
+
+    cd build
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=${ARG_INSTALL_DIR} \
+        -DWITH_TEST=OFF \
+        -DWITH_EXAMPLE=OFF \
+        -DARCH_OPT_FLAGS='' \
+        -Wno-error=unused-result \
+        ..
+    make -j${ARG_PARALLEL}
+
+    echo -e "\e[32;1mlibmkldnn was successfully built.\e[0m"
+else
+    echo -e "\e[32;1mlibmkldnn has been built.\e[0m"
+fi
+
+# install (always)
+echo -e "\e[33;1mInstalling libmkldnn\e[0m"
+
+cd ${ARG_BUILD_DIR}/mkl-dnn-${ARG_VERSION}/build
+make install/strip

--- a/.travis/install-mkldnn.sh
+++ b/.travis/install-mkldnn.sh
@@ -39,10 +39,10 @@ while [[ $# != 0 ]]; do
 done
 
 # validate the arguments
-test -n "${ARG_VERSION}" || { echo "--version is not specified"; exit 1; }
-test -n "${ARG_DOWNLOAD_DIR}" || { echo "--download-dir is not specified"; exit 1; }
-test -n "${ARG_BUILD_DIR}" || { echo "--build-dir is not specified"; exit 1; }
-test -n "${ARG_INSTALL_DIR}" || { echo "--install-dir is not specified"; exit 1; }
+test -n "${ARG_VERSION}" || { echo "--version is not specified" 1>&2; exit 1; }
+test -n "${ARG_DOWNLOAD_DIR}" || { echo "--download-dir is not specified" 1>&2; exit 1; }
+test -n "${ARG_BUILD_DIR}" || { echo "--build-dir is not specified" 1>&2; exit 1; }
+test -n "${ARG_INSTALL_DIR}" || { echo "--install-dir is not specified" 1>&2; exit 1; }
 test -n "${ARG_PARALLEL}" || ARG_PARALLEL=1
 
 # download (if it isn't cached)

--- a/.travis/install-protobuf.sh
+++ b/.travis/install-protobuf.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# retrieve arguments
+while [[ $# != 0 ]]; do
+    case $1 in
+        --)
+            shift
+            break
+            ;;
+        --version)
+            ARG_VERSION="$2"
+            shift 2
+            ;;
+        --download-dir)
+            ARG_DOWNLOAD_DIR="$2"
+            shift 2
+            ;;
+        --build-dir)
+            ARG_BUILD_DIR="$2"
+            shift 2
+            ;;
+        --install-dir)
+            ARG_INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --parallel)
+            ARG_PARALLEL="$2"
+            shift 2
+            ;;
+        -*)
+            err Unknown option \"$1\"
+            exit
+            ;;
+        *)
+            break
+            ;;
+
+    esac
+done
+
+# validate the arguments
+test -n "${ARG_VERSION}" || { echo "--version is not specified"; exit 1; }
+test -n "${ARG_DOWNLOAD_DIR}" || { echo "--download-dir is not specified"; exit 1; }
+test -n "${ARG_BUILD_DIR}" || { echo "--build-dir is not specified"; exit 1; }
+test -n "${ARG_INSTALL_DIR}" || { echo "--install-dir is not specified"; exit 1; }
+test -n "${ARG_PARALLEL}" || ARG_PARALLEL=1
+
+# download (if it isn't cached)
+if [ ! -e "${ARG_BUILD_DIR}/protobuf-${ARG_VERSION}/LICENSE" ]; then
+    echo -e "\e[33;1mDownloading libprotobuf\e[0m"
+
+    [ -d "${ARG_DOWNLOAD_DIR}" ] || mkdir -p ${ARG_DOWNLOAD_DIR}
+
+    cd ${ARG_DOWNLOAD_DIR}
+    if [ ! -e "protobuf-cpp-${ARG_VERSION}.tar.gz" ]; then
+        download_dir="https://github.com/protocolbuffers/protobuf/releases/download/v${ARG_VERSION}/protobuf-cpp-${ARG_VERSION}.tar.gz"
+        wget ${download_dir}
+    fi
+    tar -zxf protobuf-cpp-${ARG_VERSION}.tar.gz -C ${ARG_BUILD_DIR}
+
+    echo -e "\e[32;1mlibprotobuf was successfully downloaded.\e[0m"
+else
+    echo -e "\e[32;1mlibprotobuf has been downloaded.\e[0m"
+fi
+
+# build (if it isn't cached)
+if [ ! -e "${ARG_BUILD_DIR}/protobuf-${ARG_VERSION}/src/libprotobuf.la" ]; then
+    echo -e "\e[33;1mBuilding libprotobuf\e[0m"
+
+    cd ${ARG_BUILD_DIR}/protobuf-${ARG_VERSION}
+    ./configure --prefix=${ARG_INSTALL_DIR} CFLAGS=-fPIC CXXFLAGS=-fPIC
+    make -j${ARG_PARALLEL}
+
+    echo -e "\e[32;1mlibprotobuf was successfully built.\e[0m"
+else
+    echo -e "\e[32;1mlibprotobuf has been built.\e[0m"
+fi
+
+# install (always)
+echo -e "\e[33;1mInstalling libprotobuf\e[0m"
+
+cd ${ARG_BUILD_DIR}/protobuf-${ARG_VERSION}
+make install

--- a/.travis/install-protobuf.sh
+++ b/.travis/install-protobuf.sh
@@ -39,10 +39,10 @@ while [[ $# != 0 ]]; do
 done
 
 # validate the arguments
-test -n "${ARG_VERSION}" || { echo "--version is not specified"; exit 1; }
-test -n "${ARG_DOWNLOAD_DIR}" || { echo "--download-dir is not specified"; exit 1; }
-test -n "${ARG_BUILD_DIR}" || { echo "--build-dir is not specified"; exit 1; }
-test -n "${ARG_INSTALL_DIR}" || { echo "--install-dir is not specified"; exit 1; }
+test -n "${ARG_VERSION}" || { echo "--version is not specified" 1>&2; exit 1; }
+test -n "${ARG_DOWNLOAD_DIR}" || { echo "--download-dir is not specified" 1>&2; exit 1; }
+test -n "${ARG_BUILD_DIR}" || { echo "--build-dir is not specified" 1>&2; exit 1; }
+test -n "${ARG_INSTALL_DIR}" || { echo "--install-dir is not specified" 1>&2; exit 1; }
 test -n "${ARG_PARALLEL}" || ARG_PARALLEL=1
 
 # download (if it isn't cached)

--- a/.travis/linux-x86_64/build.sh
+++ b/.travis/linux-x86_64/build.sh
@@ -22,8 +22,8 @@ docker_exec "yum list installed"
 docker_exec "pip3 list"
 
 # build and test menoh
-prepare_menoh_data
 build_menoh
+prepare_menoh_data
 test_menoh
 
 # check the artifact and release

--- a/.travis/linux-x86_64/build.sh
+++ b/.travis/linux-x86_64/build.sh
@@ -18,7 +18,7 @@ install_mkldnn
 
 docker_exec "pip3 install --user chainer" # for generating test data
 
-docker_exec "yum list installed"
+docker_exec "rpm -qa"
 docker_exec "pip3 list"
 
 # build and test menoh

--- a/.travis/linux-x86_64/build.sh
+++ b/.travis/linux-x86_64/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-BASE_DIR=$(cd $(dirname $0) && pwd)
+BASE_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
 
 # initialize this script
 source ${BASE_DIR}/../init-build-linux.sh

--- a/.travis/linux-x86_64/build.sh
+++ b/.travis/linux-x86_64/build.sh
@@ -19,7 +19,7 @@ install_mkldnn
 docker_exec "pip3 install --user chainer" # for generating test data
 
 docker_exec "yum list installed"
-docker_exec "pip list"
+docker_exec "pip3 list"
 
 # build and test menoh
 prepare_menoh_data

--- a/.travis/linux-x86_64/build.sh
+++ b/.travis/linux-x86_64/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -ex
+
+BASE_DIR=$(cd $(dirname $0) && pwd)
+
+# initialize this script
+source ${BASE_DIR}/../init-build-linux.sh
+
+# check the environment
+docker_exec "ls -l ${WORK_DIR}"
+docker_exec "ls -l ${WORK_DIR}/build"
+docker_exec "ls -l ${WORK_DIR}/build/${TRAVIS_REPO_SLUG}"
+
+docker_exec "(printenv | grep PATH) && make --version && cmake --version && g++ --version && ldd --version"
+
+# build and install prerequisites
+install_protobuf
+install_mkldnn
+
+docker_exec "pip3 install --user chainer" # for generating test data
+
+docker_exec "yum list installed"
+docker_exec "pip list"
+
+# build and test menoh
+prepare_menoh_data
+build_menoh
+test_menoh
+
+# check the artifact and release
+check_menoh_artifact
+
+# release the artifact
+# TODO

--- a/.travis/macosx-x86_64/build.sh
+++ b/.travis/macosx-x86_64/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+BASE_DIR=$(cd $(dirname $0) && pwd)
+
+# initialize this script
+source ${BASE_DIR}/../init-build-osx.sh
+
+# check the environment
+ls -l ${WORK_DIR}
+ls -l ${WORK_DIR}/build
+ls -l ${WORK_DIR}/build/${TRAVIS_REPO_SLUG}
+
+printenv | grep PATH
+make --version
+cmake --version
+g++ --version
+
+# install prerequisites
+brew update
+brew upgrade python
+
+export PATH=/usr/local/opt/python/libexec/bin:$PATH
+
+brew install numpy || true
+brew install opencv mkl-dnn
+
+if [ "$LINK_STATIC" != "true" ]; then brew install protobuf; fi
+
+pip install --user chainer # for generating test data
+
+brew list --versions
+pip list
+
+# build and test menoh
+prepare_menoh_data
+build_menoh
+test_menoh
+
+# check the artifact and release
+check_menoh_artifact

--- a/.travis/macosx-x86_64/build.sh
+++ b/.travis/macosx-x86_64/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(cd $(dirname $0) && pwd)
+BASE_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
 
 # initialize this script
 source ${BASE_DIR}/../init-build-osx.sh

--- a/.travis/macosx-x86_64/build.sh
+++ b/.travis/macosx-x86_64/build.sh
@@ -32,8 +32,8 @@ brew list --versions
 pip list
 
 # build and test menoh
-prepare_menoh_data
 build_menoh
+prepare_menoh_data
 test_menoh
 
 # check the artifact and release

--- a/.travis/prepare-menoh-data.sh
+++ b/.travis/prepare-menoh-data.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# retrieve arguments
+while [[ $# != 0 ]]; do
+    case $1 in
+        --)
+            shift
+            break
+            ;;
+        --source-dir)
+            ARG_SOURCE_DIR="$2"
+            shift 2
+            ;;
+        --python-executable)
+            ARG_PYTHON_EXECUTABLE="$2"
+            shift 2
+            ;;
+        -*)
+            err Unknown option \"$1\"
+            exit
+            ;;
+        *)
+            break
+            ;;
+
+    esac
+done
+
+# validate the arguments
+test -n "${ARG_SOURCE_DIR}" || { echo "ARG_SOURCE_DIR does not exist" 1>&2; exit 1; }
+test -n "${ARG_PYTHON_EXECUTABLE}" || ARG_PYTHON_EXECUTABLE=python
+
+echo -e "\e[33;1mPreparing data/ for Menoh\e[0m"
+
+cd ${ARG_SOURCE_DIR}
+[ -d "data" ] || mkdir -p data
+
+${ARG_PYTHON_EXECUTABLE} retrieve_data.py
+${ARG_PYTHON_EXECUTABLE} gen_test_data.py

--- a/.travis/prepare-menoh-data.sh
+++ b/.travis/prepare-menoh-data.sh
@@ -27,7 +27,7 @@ while [[ $# != 0 ]]; do
 done
 
 # validate the arguments
-test -n "${ARG_SOURCE_DIR}" || { echo "ARG_SOURCE_DIR does not exist" 1>&2; exit 1; }
+test -n "${ARG_SOURCE_DIR}" || { echo "ARG_SOURCE_DIR can't be empty" 1>&2; exit 1; }
 test -n "${ARG_PYTHON_EXECUTABLE}" || ARG_PYTHON_EXECUTABLE=python
 
 echo -e "\e[33;1mPreparing data/ for Menoh\e[0m"

--- a/.travis/run-build.sh
+++ b/.travis/run-build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # check if variables have values
-test -n "${PLATFORM}" || { echo "PLATFORM does not exist"; exit 1; }
+test -n "${PLATFORM}" || { echo "PLATFORM does not exist" 1>&2; exit 1; }
 
 export PLATFORM_DIR=${TRAVIS_BUILD_DIR}/.travis/${PLATFORM}
 
 # "$TRAVIS_OS_NAME" == "linux"
 if [[ "$PLATFORM" == "linux-x86" ]] || [[ "$PLATFORM" == "linux-x86_64" ]] || [[ "$PLATFORM" =~ android ]]; then
-    test -n "${BUILDENV_IMAGE}" || { echo "BUILDENV_IMAGE does not exist"; exit 1; }
+    test -n "${BUILDENV_IMAGE}" || { echo "BUILDENV_IMAGE does not exist" 1>&2; exit 1; }
 
     docker pull ${BUILDENV_IMAGE} || true
 
@@ -22,7 +22,7 @@ if [[ "$PLATFORM" == "linux-x86" ]] || [[ "$PLATFORM" == "linux-x86_64" ]] || [[
     # See https://bugzilla.redhat.com/show_bug.cgi?id=1046469 for the details.
 
     if [ -z "${DOCKER_CONTAINER_ID}" ]; then
-        echo 'Failed to run a Docker container: '${BUILDENV_IMAGE}
+        echo 'Failed to run a Docker container: '${BUILDENV_IMAGE} 1>&2
         exit 1
     fi
 

--- a/.travis/run-build.sh
+++ b/.travis/run-build.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-echo "travis_fold:start:run-build.sh"
-echo -e "\e[33;1mRunning .travis/${PLATFORM}/run-build.sh in ${TRAVIS_REPO_SLUG}\e[0m"
-
 # check if variables have values
 test -n "${PLATFORM}" || { echo "PLATFORM does not exist"; exit 1; }
 
@@ -52,5 +49,3 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         exit 1
     fi
 fi
-
-echo "travis_fold:end:run-build.sh"

--- a/.travis/run-build.sh
+++ b/.travis/run-build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+echo "travis_fold:start:run-build.sh"
+echo -e "\e[33;1mRunning .travis/${PLATFORM}/run-build.sh in ${TRAVIS_REPO_SLUG}\e[0m"
+
+# check if variables have values
+test -n "${PLATFORM}" || { echo "PLATFORM does not exist"; exit 1; }
+
+export PLATFORM_DIR=${TRAVIS_BUILD_DIR}/.travis/${PLATFORM}
+
+# "$TRAVIS_OS_NAME" == "linux"
+if [[ "$PLATFORM" == "linux-x86" ]] || [[ "$PLATFORM" == "linux-x86_64" ]] || [[ "$PLATFORM" =~ android ]]; then
+    test -n "${BUILDENV_IMAGE}" || { echo "BUILDENV_IMAGE does not exist"; exit 1; }
+
+    docker pull ${BUILDENV_IMAGE} || true
+
+    # Run a docker container and map Travis's $HOME to the container's $HOME
+    # $HOME:$HOME = /home/travis                     : /home/travis
+    #               /home/travis/build               : /home/travis/build
+    #               /home/travis/build/<user>/<repo> : /home/travis/build/<user>/<repo> (= ${TRAVIS_BUILD_DIR})
+    # TODO: the ownership of files and directories mounted on the container
+    export DOCKER_CONTAINER_ID=$(docker run -d -it -v $HOME:$HOME -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${BUILDENV_IMAGE} /bin/bash)
+
+    # Note: You shouldn't do `docker run` with `--privileged /sbin/init`.
+    # See https://bugzilla.redhat.com/show_bug.cgi?id=1046469 for the details.
+
+    if [ -z "${DOCKER_CONTAINER_ID}" ]; then
+        echo 'Failed to run a Docker container: '${BUILDENV_IMAGE}
+        exit 1
+    fi
+
+    # Stop the container when run-build.sh exits
+    trap '[[ "$DOCKER_CONTAINER_ID" ]] && docker stop ${DOCKER_CONTAINER_ID} && docker rm -v ${DOCKER_CONTAINER_ID}' 0 1 2 3 15
+
+    docker logs ${DOCKER_CONTAINER_ID}
+
+    if [ -e "${PLATFORM_DIR}/build.sh" ]; then
+        # Dispatch to the platform specific script
+        /bin/bash -ex ${PLATFORM_DIR}/build.sh
+    else
+        echo 'The specified platform not found: '${PLATFORM} 1>&2
+        exit 1
+    fi
+fi
+
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    if [ -e "${PLATFORM_DIR}/build.sh" ]; then
+        # Dispatch to the platform specific script
+        /bin/bash -ex ${PLATFORM_DIR}/build.sh
+    else
+        echo 'The specified platform not found: '${PLATFORM} 1>&2
+        exit 1
+    fi
+fi
+
+echo "travis_fold:end:run-build.sh"

--- a/.travis/run-build.sh
+++ b/.travis/run-build.sh
@@ -5,34 +5,11 @@ test -n "${PLATFORM}" || { echo "PLATFORM can't be empty" 1>&2; exit 1; }
 
 export PLATFORM_DIR=${TRAVIS_BUILD_DIR}/.travis/${PLATFORM}
 
-# "$TRAVIS_OS_NAME" == "linux"
-if [[ "$PLATFORM" == "linux-x86" ]] || [[ "$PLATFORM" == "linux-x86_64" ]] || [[ "$PLATFORM" =~ android ]]; then
-    if [ -n "${BUILDENV_IMAGE}" ]; then
-        docker pull ${BUILDENV_IMAGE} || true
-
-        # Run a docker container and map Travis's $HOME to the container's $HOME
-        # $HOME:$HOME = /home/travis                     : /home/travis
-        #               /home/travis/build               : /home/travis/build
-        #               /home/travis/build/<user>/<repo> : /home/travis/build/<user>/<repo> (= ${TRAVIS_BUILD_DIR})
-        # TODO: the ownership of files and directories mounted on the container
-        export DOCKER_CONTAINER_ID=$(docker run -d -it -v $HOME:$HOME -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${BUILDENV_IMAGE} /bin/bash)
-
-        # Note: You shouldn't do `docker run` with `--privileged /sbin/init`.
-        # See https://bugzilla.redhat.com/show_bug.cgi?id=1046469 for the details.
-
-        if [ -z "${DOCKER_CONTAINER_ID}" ]; then
-            echo 'Failed to run a Docker container: '${BUILDENV_IMAGE} 1>&2
-            exit 1
-        fi
-
-        # Stop the container when run-build.sh exits
-        trap '[[ "${DOCKER_CONTAINER_ID}" ]] && docker stop ${DOCKER_CONTAINER_ID} && docker rm -v ${DOCKER_CONTAINER_ID}' 0 1 2 3 15
-
-        docker logs ${DOCKER_CONTAINER_ID}
-    fi
-fi
-
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    # Run some setup procedures (basically it should be done in build.sh)
+    true
+elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    # Run some setup procedures (basically it should be done in build.sh)
     true
 fi
 

--- a/.travis/run-build.sh
+++ b/.travis/run-build.sh
@@ -1,51 +1,47 @@
 #!/bin/bash
 
 # check if variables have values
-test -n "${PLATFORM}" || { echo "PLATFORM does not exist" 1>&2; exit 1; }
+test -n "${PLATFORM}" || { echo "PLATFORM can't be empty" 1>&2; exit 1; }
 
 export PLATFORM_DIR=${TRAVIS_BUILD_DIR}/.travis/${PLATFORM}
 
 # "$TRAVIS_OS_NAME" == "linux"
 if [[ "$PLATFORM" == "linux-x86" ]] || [[ "$PLATFORM" == "linux-x86_64" ]] || [[ "$PLATFORM" =~ android ]]; then
-    test -n "${BUILDENV_IMAGE}" || { echo "BUILDENV_IMAGE does not exist" 1>&2; exit 1; }
+    if [ -n "${BUILDENV_IMAGE}" ]; then
+        docker pull ${BUILDENV_IMAGE} || true
 
-    docker pull ${BUILDENV_IMAGE} || true
+        # Run a docker container and map Travis's $HOME to the container's $HOME
+        # $HOME:$HOME = /home/travis                     : /home/travis
+        #               /home/travis/build               : /home/travis/build
+        #               /home/travis/build/<user>/<repo> : /home/travis/build/<user>/<repo> (= ${TRAVIS_BUILD_DIR})
+        # TODO: the ownership of files and directories mounted on the container
+        export DOCKER_CONTAINER_ID=$(docker run -d -it -v $HOME:$HOME -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${BUILDENV_IMAGE} /bin/bash)
 
-    # Run a docker container and map Travis's $HOME to the container's $HOME
-    # $HOME:$HOME = /home/travis                     : /home/travis
-    #               /home/travis/build               : /home/travis/build
-    #               /home/travis/build/<user>/<repo> : /home/travis/build/<user>/<repo> (= ${TRAVIS_BUILD_DIR})
-    # TODO: the ownership of files and directories mounted on the container
-    export DOCKER_CONTAINER_ID=$(docker run -d -it -v $HOME:$HOME -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${BUILDENV_IMAGE} /bin/bash)
+        # Note: You shouldn't do `docker run` with `--privileged /sbin/init`.
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1046469 for the details.
 
-    # Note: You shouldn't do `docker run` with `--privileged /sbin/init`.
-    # See https://bugzilla.redhat.com/show_bug.cgi?id=1046469 for the details.
+        if [ -z "${DOCKER_CONTAINER_ID}" ]; then
+            echo 'Failed to run a Docker container: '${BUILDENV_IMAGE} 1>&2
+            exit 1
+        fi
 
-    if [ -z "${DOCKER_CONTAINER_ID}" ]; then
-        echo 'Failed to run a Docker container: '${BUILDENV_IMAGE} 1>&2
-        exit 1
-    fi
+        # Stop the container when run-build.sh exits
+        trap '[[ "${DOCKER_CONTAINER_ID}" ]] && docker stop ${DOCKER_CONTAINER_ID} && docker rm -v ${DOCKER_CONTAINER_ID}' 0 1 2 3 15
 
-    # Stop the container when run-build.sh exits
-    trap '[[ "$DOCKER_CONTAINER_ID" ]] && docker stop ${DOCKER_CONTAINER_ID} && docker rm -v ${DOCKER_CONTAINER_ID}' 0 1 2 3 15
-
-    docker logs ${DOCKER_CONTAINER_ID}
-
-    if [ -e "${PLATFORM_DIR}/build.sh" ]; then
-        # Dispatch to the platform specific script
-        /bin/bash -ex ${PLATFORM_DIR}/build.sh
-    else
-        echo 'The specified platform not found: '${PLATFORM} 1>&2
-        exit 1
+        docker logs ${DOCKER_CONTAINER_ID}
     fi
 fi
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    if [ -e "${PLATFORM_DIR}/build.sh" ]; then
-        # Dispatch to the platform specific script
-        /bin/bash -ex ${PLATFORM_DIR}/build.sh
-    else
-        echo 'The specified platform not found: '${PLATFORM} 1>&2
-        exit 1
-    fi
+    true
+fi
+
+# Dispatch to platform specific build script
+if [ -e "${PLATFORM_DIR}/build.sh" ]; then
+    /bin/bash -ex ${PLATFORM_DIR}/build.sh
+    result=$?
+    exit ${result}
+else
+    echo 'The specified platform not found: '${PLATFORM} 1>&2
+    exit 1
 fi

--- a/.travis/run-container.sh
+++ b/.travis/run-container.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Run a container for building source code and set it's container ID to ${BUILDENV_CONTAINER_ID}
+
+# retrieve arguments
+while [[ $# != 0 ]]; do
+    case $1 in
+        --)
+            shift
+            break
+            ;;
+        --image)
+            ARG_IMAGE="$2"
+            shift 2
+            ;;
+        --work-dir)
+            ARG_WORK_DIR="$2"
+            shift 2
+            ;;
+        -*)
+            err Unknown option \"$1\"
+            exit
+            ;;
+        *)
+            break
+            ;;
+
+    esac
+done
+
+unset BUILDENV_CONTAINER_ID
+
+docker pull ${ARG_IMAGE} || true
+
+# TODO: the ownership of files and directories mounted on the container
+export BUILDENV_CONTAINER_ID=$(docker run -d -it -v ${ARG_WORK_DIR}:${ARG_WORK_DIR} -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${ARG_IMAGE} /bin/bash)
+
+# Note: You shouldn't do `docker run` with `--privileged /sbin/init`.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1046469 for the details.
+
+if [ -z "${BUILDENV_CONTAINER_ID}" ]; then
+    echo 'Failed to run a Docker container: '${ARG_IMAGE} 1>&2
+    exit 1
+fi
+
+# Stop the container when run-build.sh exits
+trap '[[ "${BUILDENV_CONTAINER_ID}" ]] && docker stop ${BUILDENV_CONTAINER_ID} && docker rm -v ${BUILDENV_CONTAINER_ID}' 0 1 2 3 15
+
+docker logs ${BUILDENV_CONTAINER_ID}


### PR DESCRIPTION
Run building Menoh on Linux using Docker container. Detailed design is written in [.travis/README.md](https://github.com/pfnet-research/menoh/blob/feature/travis-dockernize/.travis/README.md).

Note: Currently `linux-x86_64` platform uses GCC 6.3.1 on CentOS 6. I'd like to use more older GCC for improving binary compatibility but I'm facing some problems. I plan to solve them later.
