### PR TITLE
input_not_found exception and output_not_found exception are added

### DIFF
--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -79,6 +79,8 @@ enum menoh_error_code_constant {
     menoh_error_code_same_named_parameter_already_exist,
     menoh_error_code_same_named_attribute_already_exist,
     menoh_error_code_invalid_backend_config_error,
+    menoh_error_code_input_not_found_error,
+    menoh_error_code_output_not_found_error,
 };
 typedef int32_t menoh_error_code;
 /*! \brief Users can get detailed message about last error.
@@ -264,6 +266,10 @@ typedef struct menoh_variable_profile_table*
   menoh_variable_profile_table_handle;
 
 /*! \brief Factory function for variable_profile_table
+ *
+ * \note this function throws menoh_input_not_found_error when no nodes have given input name.
+ * \note this function throws menoh_output_not_found_error when no nodes have given output name.
+ * \note this function throws menoh_variable_not_found_error when needed variable for model execution does not exist.
  */
 menoh_error_code MENOH_API menoh_build_variable_profile_table(
   const menoh_variable_profile_table_builder_handle builder,

--- a/menoh/attribute_completion_and_shape_inference.hpp
+++ b/menoh/attribute_completion_and_shape_inference.hpp
@@ -13,6 +13,7 @@
 
 #include <menoh/array.hpp>
 #include <menoh/model_data.hpp>
+#include <menoh/utility.hpp>
 
 namespace menoh_impl {
     inline auto complete_attribute_and_infer_shape(
@@ -32,8 +33,10 @@ namespace menoh_impl {
                     p.first,
                     array_profile(p.second.dtype(), p.second.dims())); });
         auto profile_of = [&variable_profile_table](std::string const& name){
-            assert(variable_profile_table.find(name) !=
-                variable_profile_table.end());
+            if(variable_profile_table.find(name) ==
+                variable_profile_table.end()) {
+                throw variable_not_found(name);
+            }
             return variable_profile_table.at(name);
         };
         auto dims_of = [&variable_profile_table, profile_of](

--- a/scripts/gen_attribute_completion_and_shape_inference_hpp.py
+++ b/scripts/gen_attribute_completion_and_shape_inference_hpp.py
@@ -81,6 +81,7 @@ def main():
 
 #include <menoh/array.hpp>
 #include <menoh/model_data.hpp>
+#include <menoh/utility.hpp>
 
 namespace menoh_impl {{
     inline auto complete_attribute_and_infer_shape(
@@ -100,8 +101,10 @@ namespace menoh_impl {{
                     p.first,
                     array_profile(p.second.dtype(), p.second.dims())); }});
         auto profile_of = [&variable_profile_table](std::string const& name){{
-            assert(variable_profile_table.find(name) !=
-                variable_profile_table.end());
+            if(variable_profile_table.find(name) ==
+                variable_profile_table.end()) {{
+                throw variable_not_found(name);
+            }}
             return variable_profile_table.at(name);
         }};
         auto dims_of = [&variable_profile_table, profile_of](


### PR DESCRIPTION
when building vpt,
- invalid input name causes input_not_found error
- invalid output name causes output_not_found error
- not found needed variable causes variable_not_found error