### PR TITLE
implement gemm and memory_cache

### DIFF
--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/formatted_array.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/formatted_array.hpp
@@ -1,0 +1,54 @@
+#ifndef MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_FORMATTED_ARRAY_HPP
+#define MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_FORMATTED_ARRAY_HPP
+
+#include <menoh/array.hpp>
+
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_conversion.hpp>
+
+#include <mkldnn.hpp>
+
+namespace menoh_impl {
+    namespace mkldnn_with_generic_fallback_backend {
+        namespace mkldnn_backend {
+
+            class formatted_array {
+            public:
+                formatted_array() = default;
+
+                formatted_array(mkldnn::memory::format format, array const& arr)
+                  : format_(format), array_(arr) {}
+
+                mkldnn::memory make_memory(mkldnn::memory::format format,
+                                           mkldnn::engine const& engine) const {
+                    return mkldnn::memory(
+                      {{{array_.dims()},
+                        dtype_to_mkldnn_memory_data_type(array_.dtype()),
+                        format},
+                       engine},
+                      const_cast<void*>(array_.data()));
+                }
+
+                mkldnn::memory::format format() const { return format_; }
+                menoh_impl::array array() const { return array_; }
+
+            private:
+                mkldnn::memory::format format_;
+                menoh_impl::array array_;
+            };
+
+            inline bool is_format_any(formatted_array const& farr) {
+                return farr.format() == mkldnn::memory::format::any;
+            }
+
+            inline mkldnn::memory
+            make_memory(formatted_array const& farr,
+                        mkldnn::engine const& engine) {
+                assert(farr.format() != mkldnn::memory::format::any);
+                return farr.make_memory(farr.format(), engine);
+            }
+
+        } // namespace mkldnn_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
+} // namespace menoh_impl
+
+#endif // MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_FORMATTED_ARRAY_HPP

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.cpp
@@ -1,0 +1,103 @@
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp>
+
+#include <numeric> // for accumulate
+
+#include <iostream>
+
+namespace menoh_impl {
+    namespace mkldnn_with_generic_fallback_backend {
+        namespace mkldnn_backend {
+
+            std::tuple<mkldnn::memory, optional<mkldnn::primitive>>
+            memory_cache::get_memory(std::vector<int> const& dims,
+                                     mkldnn::memory::format format) {
+                {
+                    // search matched memory
+                    auto found = std::find_if(
+                      cached_memory_list_.begin(), cached_memory_list_.end(),
+                      [&dims, format](auto const& m) {
+                          return extract_dims(m) == dims &&
+                                 extract_format(m) == format;
+                      });
+
+                    // when found
+                    if(found != cached_memory_list_.end()) {
+                        return std::make_tuple(*found, nullopt);
+                    }
+                }
+
+                if(original_array_ &&
+                   (ndims_to_data_memory_format(dims.size()) == format ||
+                    ndims_to_weight_memory_format(dims.size()) == format)) {
+                    mkldnn::memory new_memory(
+                      {{{dims},
+                        dtype_to_mkldnn_memory_data_type(
+                          original_array_->dtype()),
+                        format},
+                       engine()},
+                      const_cast<void*>(original_array_->data()));
+                    add_cached_memory(new_memory);
+                    return std::make_tuple(new_memory, nullopt);
+                }
+
+                // when not found matched memory
+                {
+                    // search same dims and format type (data or weight)
+                    // memory
+                    auto found = std::find_if(
+                      cached_memory_list_.begin(), cached_memory_list_.end(),
+                      [&dims, format](auto const& m) {
+                          return extract_dims(m) == dims &&
+                                 is_data_format(extract_format(m)) ==
+                                   is_data_format(format);
+                      });
+
+                    // when found same dims and format type memory
+                    if(found != cached_memory_list_.end()) {
+                        auto const& found_memory = *found;
+                        assert(dims == extract_dims(found_memory));
+                        mkldnn::memory new_memory(
+                          {{{dims}, extract_data_type(found_memory), format},
+                           engine()});
+                        add_cached_memory(new_memory);
+                        auto reorder_primitive =
+                          mkldnn::reorder(found_memory, new_memory);
+                        return std::make_tuple(new_memory, reorder_primitive);
+                    }
+                }
+
+                if(!original_array_) {
+                    throw std::runtime_error("not found valid array or memory");
+                }
+
+                // when not found same dims and format type memory
+                assert(original_array_);
+                assert(total_size(*original_array_) ==
+                       std::accumulate(dims.begin(), dims.end(), 1,
+                                       std::multiplies<int>()));
+
+                auto original_dtype =
+                  dtype_to_mkldnn_memory_data_type(original_array_->dtype());
+                mkldnn::memory base_memory(
+                  {{{dims},
+                    original_dtype,
+                    is_data_format(format)
+                      ? ndims_to_data_memory_format(dims.size())
+                      : ndims_to_weight_memory_format(dims.size())},
+                   engine()},
+                  const_cast<void*>(original_array_->data()));
+                std::cout << "jjj" << std::endl;
+                add_cached_memory(base_memory);
+
+                mkldnn::memory new_memory(
+                  {{{dims}, original_dtype, format}, engine()});
+                add_cached_memory(new_memory);
+
+                auto reorder_primitive =
+                  mkldnn::reorder(base_memory, new_memory);
+                return std::make_tuple(new_memory, reorder_primitive);
+            } // namespace mkldnn_backend
+
+        } // namespace mkldnn_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
+} // namespace menoh_impl

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.cpp
@@ -24,6 +24,7 @@ namespace menoh_impl {
                     }
                 }
 
+                // try to convert array to memory
                 if(original_array_ &&
                    (ndims_to_data_memory_format(dims.size()) == format ||
                     ndims_to_weight_memory_format(dims.size()) == format)) {
@@ -57,9 +58,10 @@ namespace menoh_impl {
                         mkldnn::memory new_memory(
                           {{{dims}, extract_data_type(found_memory), format},
                            engine()});
-                        add_cached_memory(new_memory);
                         auto reorder_primitive =
-                          mkldnn::reorder(found_memory, new_memory);
+                          mkldnn::reorder(found_memory,
+                                          new_memory);
+                        add_cached_memory(new_memory);
                         return std::make_tuple(new_memory, reorder_primitive);
                     }
                 }
@@ -95,8 +97,7 @@ namespace menoh_impl {
                 return std::make_tuple(new_memory, reorder_primitive);
             }
 
-            mkldnn::memory
-            memory_cache::get_data_memory() {
+            mkldnn::memory memory_cache::get_data_memory() {
                 auto found =
                   std::find_if(cached_memory_list_.begin(),
                                cached_memory_list_.end(), [](auto const& m) {

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp
@@ -21,7 +21,7 @@ namespace menoh_impl {
 
                 memory_cache(array const& arr, mkldnn::engine const& engine)
                   : original_array_(arr), engine_(engine) {}
-                memory_cache(mkldnn::memory const& mem)
+                explicit memory_cache(mkldnn::memory const& mem)
                   : cached_memory_list_({mem}),
                     engine_(mem.get_primitive_desc().get_engine()) {}
 
@@ -42,7 +42,10 @@ namespace menoh_impl {
                     return extract_dims(cached_memory_list_.front());
                 }
 
-                mkldnn::engine engine() const { return *engine_; }
+                mkldnn::engine const& engine() const {
+                    assert(engine_ && "engine_ is not set");
+                    return *engine_;
+                }
 
                 std::tuple<mkldnn::memory, optional<mkldnn::primitive>>
                 get_memory(std::vector<int> const& dims,
@@ -54,6 +57,7 @@ namespace menoh_impl {
                     // check format is different
                     // MEMO: dims may be different (eg FC's weight for 4d input
                     // and 2d input)
+                    assert(engine_ && "please use non default constructor");
                     if(original_array_) {
                         auto mdims = extract_dims(added_memory);
                         assert(total_size(*original_array_) ==

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp
@@ -1,8 +1,8 @@
 #ifndef MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_MEMORY_CACHE_HPP
 #define MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_MEMORY_CACHE_HPP
 
-#include <tuple>
 #include <numeric>
+#include <tuple>
 
 #include <menoh/array.hpp>
 #include <menoh/optional.hpp>
@@ -47,6 +47,8 @@ namespace menoh_impl {
                 std::tuple<mkldnn::memory, optional<mkldnn::primitive>>
                 get_memory(std::vector<int> const& dims,
                            mkldnn::memory::format format);
+
+                mkldnn::memory get_data_memory();
 
                 void add_cached_memory(mkldnn::memory const& added_memory) {
                     // check format is different

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp
@@ -1,0 +1,100 @@
+#ifndef MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_MEMORY_CACHE_HPP
+#define MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_MEMORY_CACHE_HPP
+
+#include <tuple>
+#include <numeric>
+
+#include <menoh/array.hpp>
+#include <menoh/optional.hpp>
+
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_conversion.hpp>
+
+#include <mkldnn.hpp>
+
+namespace menoh_impl {
+    namespace mkldnn_with_generic_fallback_backend {
+        namespace mkldnn_backend {
+
+            class memory_cache {
+            public:
+                memory_cache() = default;
+
+                memory_cache(array const& arr, mkldnn::engine const& engine)
+                  : original_array_(arr), engine_(engine) {}
+                memory_cache(mkldnn::memory const& mem)
+                  : cached_memory_list_({mem}),
+                    engine_(mem.get_primitive_desc().get_engine()) {}
+
+                mkldnn::memory::data_type dtype() const {
+                    if(original_array_) {
+                        return dtype_to_mkldnn_memory_data_type(
+                          original_array_->dtype());
+                    }
+                    assert(!cached_memory_list_.empty());
+                    return extract_data_type(cached_memory_list_.front());
+                }
+
+                std::vector<int> dims() const {
+                    if(original_array_) {
+                        return original_array_->dims();
+                    }
+                    assert(!cached_memory_list_.empty());
+                    return extract_dims(cached_memory_list_.front());
+                }
+
+                mkldnn::engine engine() const { return *engine_; }
+
+                std::tuple<mkldnn::memory, optional<mkldnn::primitive>>
+                get_memory(std::vector<int> const& dims,
+                           mkldnn::memory::format format);
+
+                void add_cached_memory(mkldnn::memory const& added_memory) {
+                    // check format is different
+                    // MEMO: dims may be different (eg FC's weight for 4d input
+                    // and 2d input)
+                    if(original_array_) {
+                        auto mdims = extract_dims(added_memory);
+                        assert(total_size(*original_array_) ==
+                               std::accumulate(mdims.begin(), mdims.end(), 1,
+                                               std::multiplies<int>()));
+                    }
+                    for(auto const& cached_memory : cached_memory_list_) {
+                        assert(extract_format(cached_memory) !=
+                               extract_format(added_memory));
+                    }
+
+                    cached_memory_list_.push_back(added_memory);
+                }
+
+            private:
+                optional<array> original_array_ = nullopt;
+                std::vector<mkldnn::memory> cached_memory_list_;
+                optional<mkldnn::engine> engine_;
+            };
+
+            mkldnn::memory inline get_memory(
+              memory_cache& mem_cache, std::vector<int> const& dims,
+              mkldnn::memory::format format,
+              std::vector<mkldnn::primitive>& primitives) {
+                optional<mkldnn::memory> mem;
+                optional<mkldnn::primitive> reorder_primitive;
+                std::tie(mem, reorder_primitive) =
+                  mem_cache.get_memory(dims, format);
+                if(reorder_primitive) {
+                    primitives.push_back(*reorder_primitive);
+                }
+                return *mem;
+            }
+
+            mkldnn::memory inline get_memory(
+              memory_cache& mem_cache, mkldnn::memory::format format,
+              std::vector<mkldnn::primitive>& primitives) {
+                return get_memory(mem_cache, mem_cache.dims(), format,
+                                  primitives);
+            }
+
+        } // namespace mkldnn_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
+} // namespace menoh_impl
+
+#endif // MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_MEMORY_CACHE_HPP

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp
@@ -25,7 +25,7 @@ namespace menoh_impl {
                   : cached_memory_list_({mem}),
                     engine_(mem.get_primitive_desc().get_engine()) {}
 
-                mkldnn::memory::data_type dtype() const {
+                mkldnn::memory::data_type data_type() const {
                     if(original_array_) {
                         return dtype_to_mkldnn_memory_data_type(
                           original_array_->dtype());

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_conversion.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_conversion.cpp
@@ -1,0 +1,156 @@
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_conversion.hpp>
+
+namespace menoh_impl {
+    namespace mkldnn_with_generic_fallback_backend {
+        namespace mkldnn_backend {
+
+            bool is_data_format(mkldnn::memory::format format) {
+                std::vector<mkldnn::memory::format> data_memory_formats(
+                  {mkldnn::memory::format::x, //
+                   mkldnn::memory::format::nc,
+                   // mkldnn::memory::format::ncw,
+                   // mkldnn::memory::format::nwc,
+                   // mkldnn::memory::format::nCw16c,
+                   mkldnn::memory::format::nchw,
+                   // mkldnn::memory::format::nhwc,
+                   mkldnn::memory::format::chwn,
+                   // mkldnn::memory::format::nCw8c,
+                   mkldnn::memory::format::nChw8c,
+                   mkldnn::memory::format::nChw16c,
+                   mkldnn::memory::format::ncdhw, //
+                   mkldnn::memory::format::ndhwc,
+                   // mkldnn::memory::format::nCdhw8c,
+                   mkldnn::memory::format::nCdhw16c});
+                return std::find(data_memory_formats.begin(),
+                                 data_memory_formats.end(),
+                                 format) != data_memory_formats.end();
+            }
+
+            std::vector<int> extract_dims(mkldnn::memory const& m) {
+                auto const& d = m.get_primitive_desc().desc().data;
+                return std::vector<int>(d.dims, d.dims + d.ndims);
+            }
+
+            mkldnn::memory::format extract_format(mkldnn::memory const& m) {
+                auto const& d = m.get_primitive_desc().desc().data;
+                return static_cast<mkldnn::memory::format>(d.format);
+            }
+
+            mkldnn::memory::data_type
+            extract_data_type(mkldnn::memory const& m) {
+                auto const& d = m.get_primitive_desc().desc().data;
+                return static_cast<mkldnn::memory::data_type>(d.data_type);
+            }
+
+            mkldnn::memory::data_type
+            dtype_to_mkldnn_memory_data_type(dtype_t dtype) {
+                if(dtype == dtype_t::float_) {
+                    return mkldnn::memory::data_type::f32;
+                }
+                throw invalid_dtype(std::to_string(static_cast<int>(dtype)));
+            }
+
+            dtype_t mkldnn_memory_data_type_to_dtype(
+              mkldnn::memory::data_type mem_data_type) {
+                if(mem_data_type == mkldnn::memory::data_type::f32) {
+                    return dtype_t::float_;
+                }
+                throw invalid_dtype(
+                  std::to_string(static_cast<int>(mem_data_type)));
+            }
+
+            mkldnn::memory::format ndims_to_data_memory_format(int ndims) {
+                if(ndims == 1) {
+                    return mkldnn::memory::format::x;
+                }
+                if(ndims == 2) {
+                    return mkldnn::memory::format::nc;
+                }
+                /*
+                if(ndims == 3) {
+                    return mkldnn::memory::format::ncw;
+                }
+                */
+                if(ndims == 4) {
+                    return mkldnn::memory::format::nchw;
+                }
+                throw std::runtime_error("ndims_to_data_memory_format: invalid ndims: " + std::to_string(ndims));
+            }
+
+            mkldnn::memory::format ndims_to_weight_memory_format(int ndims) {
+                if(ndims == 1) {
+                    return mkldnn::memory::format::x;
+                }
+                if(ndims == 2) {
+                    return mkldnn::memory::format::oi;
+                }
+                /*
+                if(ndims == 3) {
+                    return mkldnn::memory::format::oiw;
+                }
+                */
+                if(ndims == 4) {
+                    return mkldnn::memory::format::oihw;
+                }
+                throw std::runtime_error("ndims_to_weight_memory_format: invalid ndims" + std::to_string(ndims));
+            }
+
+            mkldnn::memory array_to_memory(array const& arr,
+                                           std::vector<int> const& dims,
+                                           mkldnn::memory::format format,
+                                           mkldnn::engine const& engine) {
+                return mkldnn::memory(
+                  {{{dims},
+                    dtype_to_mkldnn_memory_data_type(arr.dtype()),
+                    format},
+                   engine},
+                  const_cast<void*>(arr.data()));
+            }
+
+            mkldnn::memory array_to_memory(array const& arr,
+                                           mkldnn::memory::format format,
+                                           mkldnn::engine const& engine) {
+                return array_to_memory(arr, arr.dims(), format, engine);
+            }
+
+            mkldnn::memory array_to_data_memory(array const& arr,
+                                                mkldnn::engine const& engine) {
+                return array_to_memory(
+                  arr, arr.dims(),
+                  ndims_to_data_memory_format(arr.dims().size()), engine);
+            }
+
+            array memory_to_array(mkldnn::memory const& mem) {
+                assert(extract_format(mem) == mkldnn::memory::format::x ||
+                       extract_format(mem) == mkldnn::memory::format::nc ||
+                       // extract_format(mem) == mkldnn::memory::format::ncw ||
+                       extract_format(mem) == mkldnn::memory::format::nchw);
+                return array(
+                  mkldnn_memory_data_type_to_dtype(
+                    static_cast<mkldnn::memory::data_type>(
+                      mem.get_primitive_desc().desc().data.data_type)),
+                  extract_dims(mem), mem.get_data_handle());
+            }
+
+            mkldnn::memory
+            make_memory_from_array_profile(array_profile const& profile,
+                                           mkldnn::memory::format format,
+                                           mkldnn::engine const& engine) {
+                return mkldnn::memory(
+                  {{{profile.dims()},
+                    dtype_to_mkldnn_memory_data_type(profile.dtype()),
+                    format},
+                   engine});
+            }
+
+            mkldnn::memory
+            make_data_memory_from_array_profile(array_profile const& profile,
+                                                mkldnn::engine const& engine) {
+                return make_memory_from_array_profile(
+                  profile, ndims_to_data_memory_format(profile.dims().size()),
+                  engine);
+            }
+
+        } // namespace mkldnn_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
+} // namespace menoh_impl

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_conversion.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_conversion.hpp
@@ -1,0 +1,55 @@
+#ifndef MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_MEMORY_CONVERSION_HPP
+#define MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_MEMORY_CONVERSION_HPP
+
+#include <menoh/array.hpp>
+
+#include <mkldnn.hpp>
+
+namespace menoh_impl {
+    namespace mkldnn_with_generic_fallback_backend {
+        namespace mkldnn_backend {
+
+            bool is_data_format(mkldnn::memory::format format);
+
+            std::vector<int> extract_dims(mkldnn::memory const& m);
+            mkldnn::memory::format extract_format(mkldnn::memory const& m);
+            mkldnn::memory::data_type
+            extract_data_type(mkldnn::memory const& m);
+
+            mkldnn::memory::data_type
+            dtype_to_mkldnn_memory_data_type(dtype_t dtype);
+
+            dtype_t mkldnn_memory_data_type_to_dtype(
+              mkldnn::memory::data_type mem_data_type);
+
+            mkldnn::memory::format ndims_to_data_memory_format(int ndims);
+            mkldnn::memory::format ndims_to_weight_memory_format(int ndims);
+
+            mkldnn::memory array_to_memory(array const& arr,
+                                           std::vector<int> const& dims,
+                                           mkldnn::memory::format format,
+                                           mkldnn::engine const& engine);
+
+            mkldnn::memory array_to_memory(array const& arr,
+                                           mkldnn::memory::format format,
+                                           mkldnn::engine const& engine);
+
+            mkldnn::memory array_to_data_memory(array const& arr,
+                                                mkldnn::engine const& engine);
+
+            array memory_to_array(mkldnn::memory const& mem);
+
+            mkldnn::memory
+            make_memory_from_array_profile(array_profile const& profile,
+                                           mkldnn::memory::format format,
+                                           mkldnn::engine const& engine);
+
+            mkldnn::memory
+            make_data_memory_from_array_profile(array_profile const& profile,
+                                                mkldnn::engine const& engine);
+
+        } // namespace mkldnn_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
+} // namespace menoh_impl
+
+#endif // MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_MKLDNN_MEMORY_CONVERSION_HPP

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
@@ -115,6 +115,7 @@ namespace menoh_impl {
                                 }
 
                                 // search in other contexts' variable table
+                                bool is_found_from_other_context = false;
                                 for(auto const& context_pair : context_list) {
                                     if(context_pair.first == context_name) {
                                         continue; // skip self
@@ -143,10 +144,11 @@ namespace menoh_impl {
                                           "already same named variable exist");
                                         input_memory_cache_list.push_back(
                                           std::ref(result_pair.first->second));
+                                        is_found_from_other_context = true;
                                         break;
                                     }
                                 }
-                                assert(!"never come here");
+                                assert(is_found_from_other_context);
                             } while(false);
                         }
 
@@ -227,9 +229,18 @@ namespace menoh_impl {
                 }
 
                 procedure_list.emplace_back([this, primitive_list]() {
+                    /*
                     mkldnn::stream(mkldnn::stream::kind::eager)
                       .submit(primitive_list)
                       .wait();
+                    */
+                    int i = 0;
+                    for(auto const& primitive : primitive_list) {
+                        mkldnn::stream(mkldnn::stream::kind::eager)
+                          .submit({primitive})
+                          .wait();
+                        ++i;
+                    }
                 });
 
                 return std::make_tuple(procedure_list, current_index);

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
@@ -229,18 +229,9 @@ namespace menoh_impl {
                 }
 
                 procedure_list.emplace_back([this, primitive_list]() {
-                    /*
                     mkldnn::stream(mkldnn::stream::kind::eager)
                       .submit(primitive_list)
                       .wait();
-                    */
-                    int i = 0;
-                    for(auto const& primitive : primitive_list) {
-                        mkldnn::stream(mkldnn::stream::kind::eager)
-                          .submit({primitive})
-                          .wait();
-                        ++i;
-                    }
                 });
 
                 return std::make_tuple(procedure_list, current_index);

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
@@ -66,7 +66,7 @@ namespace menoh_impl {
                                                          engine_));
                                         assert(
                                           result_pair.second &&
-                                          "alredy same named variable exist");
+                                          "already same named variable exist");
                                         input_memory_cache_list.push_back(
                                           std::ref(result_pair.first->second));
                                         break;
@@ -106,7 +106,7 @@ namespace menoh_impl {
                                                          engine_));
                                         assert(
                                           result_pair.second &&
-                                          "alredy same named variable exist");
+                                          "already same named variable exist");
                                         input_memory_cache_list.push_back(
                                           std::ref(result_pair.first->second));
                                         break;
@@ -139,7 +139,7 @@ namespace menoh_impl {
                                             memory_cache(arr, engine_));
                                         assert(
                                           result_pair.second &&
-                                          "alredy same named variable exist");
+                                          "already same named variable exist");
                                         input_memory_cache_list.push_back(
                                           std::ref(result_pair.first->second));
                                         break;

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
@@ -1,9 +1,8 @@
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_conversion.hpp>
 #include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.hpp>
 #include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator.hpp>
 
 #include <menoh/graph.hpp> // for unsupported_operator error
-
-#include <menoh/mkldnn/utility.hpp>
 
 namespace menoh_impl {
     namespace mkldnn_with_generic_fallback_backend {
@@ -31,6 +30,7 @@ namespace menoh_impl {
                 context_list,
               logger_handle logger) {
                 static_cast<void>(output_profile_table); // maybe unused
+
                 auto first_node_index = current_index;
                 std::vector<procedure> procedure_list;
 
@@ -39,61 +39,81 @@ namespace menoh_impl {
                 for(; current_index < static_cast<int>(node_list.size());
                     ++current_index) {
                     auto const& node = node_list.at(current_index);
-                    std::vector<array> input_list;
+
                     std::vector<procedure> new_copy_procedure_list;
                     std::vector<mkldnn::primitive> new_primitive_list;
-                    std::vector<std::pair<std::string, mkldnn::memory>>
-                      new_output_memory_list;
-                    std::vector<mkldnn::memory> new_temp_memory_list;
+                    std::vector<std::pair<std::string, memory_cache>>
+                      new_named_output_memory_cache_list;
 
                     try {
+                        std::vector<std::reference_wrapper<memory_cache>>
+                          input_memory_cache_list;
                         for(auto const& input_name : node.input_name_list) {
                             do {
-                                // search in self variable table
-                                auto found_from_variable_memory_table =
-                                  variable_memory_table_.find(input_name);
-                                if(found_from_variable_memory_table !=
-                                   variable_memory_table_.end()) {
-                                    *logger
-                                      << input_name
-                                      << " is found in self variable table"
-                                      << std::endl;
-                                    input_list.push_back(
-                                      menoh_impl::mkldnn_backend::
-                                        memory_to_array(
-                                          found_from_variable_memory_table
-                                            ->second));
-                                    break;
+                                // search in common parameter table
+                                {
+                                    auto found =
+                                      common_parameter_table.find(input_name);
+                                    if(found != common_parameter_table.end()) {
+                                        *logger << input_name
+                                                << " is found from self common "
+                                                   "parameter table"
+                                                << std::endl;
+                                        auto result_pair =
+                                          variable_memory_cache_table_.emplace(
+                                            input_name,
+                                            memory_cache(found->second,
+                                                         engine_));
+                                        assert(
+                                          result_pair.second &&
+                                          "alredy same named variable exist");
+                                        input_memory_cache_list.push_back(
+                                          std::ref(result_pair.first->second));
+                                        break;
+                                    }
                                 }
 
-                                // search in common parameter and input table
-                                auto found_from_common_table = [&](auto const&
-                                                                     table) {
-                                    auto found = table.find(input_name);
-                                    if(found != table.end()) {
-                                        input_list.push_back(found->second);
-                                        return true;
+                                // search in self variable table
+                                {
+                                    auto found =
+                                      variable_memory_cache_table_.find(
+                                        input_name);
+                                    if(found !=
+                                       variable_memory_cache_table_.end()) {
+                                        *logger << input_name
+                                                << " is found from self "
+                                                   "variable table"
+                                                << std::endl;
+                                        input_memory_cache_list.push_back(
+                                          found->second);
+                                        break;
                                     }
-                                    return false;
-                                };
-                                if(found_from_common_table(
-                                     common_parameter_table)) {
-                                    *logger
-                                      << input_name
-                                      << " is found in common parameter table"
-                                      << std::endl;
-                                    break;
                                 }
-                                if(found_from_common_table(
-                                     common_input_table)) {
-                                    *logger << input_name
-                                            << " is found in common input table"
-                                            << std::endl;
-                                    break;
+
+                                // search in common input table
+                                {
+                                    auto found =
+                                      common_input_table.find(input_name);
+                                    if(found != common_input_table.end()) {
+                                        *logger << input_name
+                                                << " is found from self common "
+                                                   "input table"
+                                                << std::endl;
+                                        auto result_pair =
+                                          variable_memory_cache_table_.emplace(
+                                            input_name,
+                                            memory_cache(found->second,
+                                                         engine_));
+                                        assert(
+                                          result_pair.second &&
+                                          "alredy same named variable exist");
+                                        input_memory_cache_list.push_back(
+                                          std::ref(result_pair.first->second));
+                                        break;
+                                    }
                                 }
 
                                 // search in other contexts' variable table
-                                bool is_found_from_other_context = false;
                                 for(auto const& context_pair : context_list) {
                                     if(context_pair.first == context_name) {
                                         continue; // skip self
@@ -113,23 +133,55 @@ namespace menoh_impl {
                                         std::tie(copy_proc, arr) = *found;
                                         new_copy_procedure_list.push_back(
                                           copy_proc);
-                                        input_list.push_back(arr);
-                                        is_found_from_other_context = true;
+                                        auto result_pair =
+                                          variable_memory_cache_table_.emplace(
+                                            input_name,
+                                            memory_cache(arr, engine_));
+                                        assert(
+                                          result_pair.second &&
+                                          "alredy same named variable exist");
+                                        input_memory_cache_list.push_back(
+                                          std::ref(result_pair.first->second));
                                         break;
                                     }
                                 }
-                                assert(is_found_from_other_context);
+                                assert(!"never come here");
                             } while(false);
                         }
 
-                        // make primitives and
-                        auto factory =
-                          procedure_factory_table_.at(node.op_type);
-                        std::tie(new_primitive_list, new_output_memory_list,
-                                 new_temp_memory_list) =
-                          factory.operator()(current_index, node_list,
-                                             input_list, required_output_table,
-                                             engine_);
+                        std::vector<mkldnn::memory> output_memory_list;
+                        for(auto const& output_name : node.output_name_list) {
+                            auto found =
+                              required_output_table.find(output_name);
+                            assert(
+                              variable_memory_cache_table_.find(output_name) ==
+                                variable_memory_cache_table_.end() &&
+                              "variable have not already exist");
+                            if(found == required_output_table.end()) {
+                                // not required output
+                                // add `any` format memory
+                                output_memory_list.push_back(
+                                  make_memory_from_array_profile(
+                                    output_profile_table.at(output_name),
+                                    mkldnn::memory::format::any, engine_));
+                            } else {
+                                // required output
+                                output_memory_list.push_back(
+                                  array_to_data_memory(found->second, engine_));
+                            }
+                        }
+
+                        auto found =
+                          procedure_factory_table_.find(node.op_type);
+                        if(found == procedure_factory_table_.end()) {
+                            throw std::runtime_error("factory not found for: " +
+                                                     node.op_type);
+                        }
+                        auto factory = found->second;
+                        std::tie(new_primitive_list,
+                                 new_named_output_memory_cache_list) =
+                          factory.operator()(node, input_memory_cache_list,
+                                             output_memory_list, engine_);
                     } catch(std::exception const& e) {
                         *logger << e.what() << std::endl;
                         break;
@@ -146,13 +198,9 @@ namespace menoh_impl {
                       std::make_move_iterator(new_copy_procedure_list.end()));
 
                     // update context
-                    variable_memory_table_.insert(
-                      std::make_move_iterator(new_output_memory_list.begin()),
-                      std::make_move_iterator(new_output_memory_list.end()));
-                    temp_memory_list_.insert(
-                      temp_memory_list_.end(),
-                      std::make_move_iterator(new_temp_memory_list.begin()),
-                      std::make_move_iterator(new_temp_memory_list.end()));
+                    variable_memory_cache_table_.insert(
+                      new_named_output_memory_cache_list.begin(),
+                      new_named_output_memory_cache_list.end());
                 }
 
                 // when no nodes are processed

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.hpp
@@ -1,14 +1,22 @@
 #ifndef MENOH_IMPL_MKLDNN_WITH_FALLBACK_BACKEND_BACKEND_MKLDNN_MKLDNN_CONTEXT_HPP
 #define MENOH_IMPL_MKLDNN_WITH_FALLBACK_BACKEND_BACKEND_MKLDNN_MKLDNN_CONTEXT_HPP
 
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <mkldnn.hpp>
+
+#include <menoh/any.hpp>
 #include <menoh/array.hpp>
 #include <menoh/mkldnn/utility.hpp>
 #include <menoh/model_core.hpp>
 
-#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp>
 #include <menoh/mkldnn_with_generic_fallback/context.hpp>
 
-#include <mkldnn.hpp>
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/formatted_array.hpp>
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp>
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/procedure_factory.hpp>
 
 namespace menoh_impl {
     namespace mkldnn_with_generic_fallback_backend {
@@ -70,19 +78,12 @@ namespace menoh_impl {
                     return variable_memory_cache_table_.at(name);
                 }
 
-                using procedure_factory = std::function<
-                  std::tuple<std::vector<mkldnn::primitive>,
-                             std::vector<std::pair<std::string, memory_cache>>>(
-                    node const&,
-                    std::vector<std::reference_wrapper<
-                      memory_cache>> const&, // input_memory_cache_list
-                    std::vector<mkldnn::memory> const&, // output_memory_list
-                    mkldnn::engine const&               // engine
-                    )>;
-
                 mkldnn::engine engine_{mkldnn::engine::kind::cpu, 0}; // TODO
+                std::vector<array> allocated_array_list_;
                 std::unordered_map<std::string, memory_cache>
                   variable_memory_cache_table_;
+                std::unordered_map<std::string, memory_cache>
+                  temp_memory_cache_table_;
                 std::unordered_map<std::string, procedure_factory>
                   procedure_factory_table_;
             };

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.hpp
@@ -5,6 +5,7 @@
 #include <menoh/mkldnn/utility.hpp>
 #include <menoh/model_core.hpp>
 
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp>
 #include <menoh/mkldnn_with_generic_fallback/context.hpp>
 
 #include <mkldnn.hpp>
@@ -20,42 +21,30 @@ namespace menoh_impl {
             private:
                 virtual optional<std::tuple<procedure, array>>
                 do_try_to_get_variable(std::string const& name) override {
-                    auto found = variable_memory_table_.find(name);
-                    if(found == variable_memory_table_.end()) {
+                    auto found = variable_memory_cache_table_.find(name);
+                    if(found == variable_memory_cache_table_.end()) {
                         return nullopt;
                     }
-                    auto dims =
-                      ::menoh_impl::mkldnn_backend::extract_dims(found->second);
-                    auto variable_memory = found->second; // mutable
-                    procedure copy_proc(nullptr);         // mutable
-                    if(dims.size() == 4) {
-                        auto format = static_cast<mkldnn::memory::format>(
-                          found->second.get_primitive_desc()
-                            .desc()
-                            .data.format);
-                        if(format != mkldnn::memory::nchw) {
-                            auto data_type =
-                              static_cast<mkldnn::memory::data_type>(
-                                found->second.get_primitive_desc()
-                                  .desc()
-                                  .data.data_type);
-                            variable_memory = mkldnn::memory(
-                              {{dims, data_type, mkldnn::memory::format::nchw},
-                               engine_});
-                            temp_memory_list_.push_back(variable_memory);
-                            std::vector<mkldnn::primitive> primitives(
-                              {mkldnn::reorder(found->second,
-                                               variable_memory)});
-                            copy_proc = [primitives]() {
-                                mkldnn::stream(mkldnn::stream::kind::eager)
-                                  .submit(primitives)
-                                  .wait();
-                            };
-                        }
-                    }
+                    auto& variable_memory_cache = found->second;
+                    std::vector<mkldnn::primitive> primitives;
+                    auto variable_memory =
+                      get_memory(variable_memory_cache,
+                                 ndims_to_data_memory_format(
+                                   variable_memory_cache.dims().size()),
+                                 primitives);
+                    procedure copy_proc =
+                      primitives.empty()
+                        ? procedure(nullptr)
+                        : procedure([primitives] {
+                              mkldnn::stream(mkldnn::stream::kind::eager)
+                                .submit(primitives)
+                                .wait();
+                          });
                     return std::make_tuple(
-                      copy_proc, array(dtype_t::float_, dims,
-                                       found->second.get_data_handle()));
+                      copy_proc, array(mkldnn_memory_data_type_to_dtype(
+                                         extract_data_type(variable_memory)),
+                                       extract_dims(variable_memory),
+                                       variable_memory.get_data_handle()));
                 }
 
                 virtual optional<std::tuple<std::vector<procedure>, int>>
@@ -78,21 +67,22 @@ namespace menoh_impl {
                 // for specialized optimization across backends
                 virtual any
                 do_take_variable_handle(std::string const& name) override {
-                    return variable_memory_table_.at(name);
+                    return variable_memory_cache_table_.at(name);
                 }
 
-                using procedure_factory = std::function<std::tuple<
-                  std::vector<mkldnn::primitive>,
-                  std::vector<std::pair<std::string, mkldnn::memory>>,
-                  std::vector<mkldnn::memory>>(
-                  int, std::vector<node> const&, std::vector<array> const&,
-                  std::unordered_map<std::string, array> const&,
-                  mkldnn::engine const&)>;
+                using procedure_factory = std::function<
+                  std::tuple<std::vector<mkldnn::primitive>,
+                             std::vector<std::pair<std::string, memory_cache>>>(
+                    node const&,
+                    std::vector<std::reference_wrapper<
+                      memory_cache>> const&, // input_memory_cache_list
+                    std::vector<mkldnn::memory> const&, // output_memory_list
+                    mkldnn::engine const&               // engine
+                    )>;
 
                 mkldnn::engine engine_{mkldnn::engine::kind::cpu, 0}; // TODO
-                std::unordered_map<std::string, mkldnn::memory>
-                  variable_memory_table_;
-                std::vector<mkldnn::memory> temp_memory_list_;
+                std::unordered_map<std::string, memory_cache>
+                  variable_memory_cache_table_;
                 std::unordered_map<std::string, procedure_factory>
                   procedure_factory_table_;
             };

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
@@ -13,7 +13,7 @@ namespace menoh_impl {
         namespace mkldnn_backend {
 
             inline procedure_factory_return_type
-            MENOH_MKLDNN_CONTEXT_PROCEDURE_FACTORY(make_gemm) {
+            make_gemm(MENOH_MKLDNN_CONTEXT_PROCEDURE_FACTORY_PARAMETER_LIST) {
 
                 std::vector<mkldnn::primitive> primitives;
 

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
@@ -94,7 +94,6 @@ namespace menoh_impl {
                   gemm_output_md);
                 auto gemm_pd = mkldnn::inner_product_forward::primitive_desc(
                   gemm_desc, engine);
-                auto op_input_dims = extract_dims(gemm_pd.src_primitive_desc());
 
                 auto input_memory = get_memory(
                   input_memory_cache,

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
@@ -56,7 +56,7 @@ namespace menoh_impl {
                 auto weight_dims = weight_memory_cache.dims(); // mutable
                 assert(weight_dims.size() == 2);
                 if(input_dims.size() != 2) {
-                    weight_dims = std::vector<int>{weight_dims.front()};
+                    weight_dims = std::vector<int>({weight_dims.front()});
                     weight_dims.insert(weight_dims.end(),
                                        input_dims.begin() + 1,
                                        input_dims.end());
@@ -66,11 +66,7 @@ namespace menoh_impl {
                 auto bias_dims = bias_memory_cache.dims();
                 int output_size = weight_dims.at(0);
                 if(output_size != bias_dims.at(0)) {
-                    throw failed_to_configure_operator(
-                      node.op_type, node.output_name_list.at(0),
-                      "dims[0] of input C must be equal to dims[0] of "
-                      "input B: "
-                      "broadcast is not supported yet");
+                    throw std::runtime_error("broadcast is not supported yet");
                 }
 
                 auto output_dims =
@@ -98,6 +94,7 @@ namespace menoh_impl {
                   gemm_output_md);
                 auto gemm_pd = mkldnn::inner_product_forward::primitive_desc(
                   gemm_desc, engine);
+                auto op_input_dims = extract_dims(gemm_pd.src_primitive_desc());
 
                 auto input_memory = get_memory(
                   input_memory_cache,

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
@@ -18,8 +18,6 @@ namespace menoh_impl {
                       mkldnn::engine const& engine) {
 
                 std::vector<mkldnn::primitive> primitives;
-                std::vector<mkldnn::memory> temp_memory_list;
-                std::vector<array> owned_array_list;
 
                 auto alpha = optional_attribute_float(node, "alpha", 1.f);
                 if(alpha != 1) {

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/gemm.hpp
@@ -1,27 +1,25 @@
 #ifndef MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_MKLDNN_OPERATOR_GEMM_HPP
 #define MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_MKLDNN_OPERATOR_GEMM_HPP
 
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp>
+
+#include <mkldnn.hpp>
+
 namespace menoh_impl {
     namespace mkldnn_with_generic_fallback_backend {
         namespace mkldnn_backend {
 
-            inline std::tuple<
-              std::vector<mkldnn::primitive>,
-              std::vector<std::pair<std::string, mkldnn::memory>>,
-              std::vector<mkldnn::memory>>
-            make_gemm(int node_index, std::vector<node> const& node_list,
-                      std::vector<array> const& input_list,
-                      std::unordered_map<std::string, array> const&
-                        required_output_table,
+            inline std::tuple<std::vector<mkldnn::primitive>,
+                              std::vector<std::pair<std::string, memory_cache>>>
+            make_gemm(node const& node,
+                      std::vector<std::reference_wrapper<memory_cache>> const&
+                        input_memory_cache_list,
+                      std::vector<mkldnn::memory> const& output_memory_list,
                       mkldnn::engine const& engine) {
 
-                using namespace menoh_impl::mkldnn_backend;
                 std::vector<mkldnn::primitive> primitives;
-                std::unordered_map<std::string, array> output_table;
                 std::vector<mkldnn::memory> temp_memory_list;
                 std::vector<array> owned_array_list;
-
-                auto node = node_list.at(node_index);
 
                 auto alpha = optional_attribute_float(node, "alpha", 1.f);
                 if(alpha != 1) {
@@ -53,56 +51,50 @@ namespace menoh_impl {
                         std::to_string(alpha));
                 }
 
-                auto input_dims = input_list.at(0).dims();
-                auto input_format =
-                  (input_dims.size() == 2 ? mkldnn::memory::format::nc
-                                          : mkldnn::memory::format::nchw);
-                auto input_memory =
-                  array_to_memory(input_list.at(0), input_format, engine);
-                temp_memory_list.push_back(input_memory);
+                memory_cache& input_memory_cache =
+                  input_memory_cache_list.at(0);
+                auto input_dims = input_memory_cache.dims();
 
-                auto const& weight_arr = input_list.at(1);
-                auto weight_dims = weight_arr.dims();
-                auto weight_format =
-                  (input_dims.size() == 2 ? mkldnn::memory::format::oi
-                                          : mkldnn::memory::format::oihw);
-                if(weight_format == mkldnn::memory::format::oihw) {
+                memory_cache& weight_memory_cache =
+                  input_memory_cache_list.at(1);
+                auto weight_dims = weight_memory_cache.dims(); // mutable
+                assert(weight_dims.size() == 2);
+                if(input_dims.size() != 2) {
                     weight_dims = std::vector<int>{weight_dims.front()};
                     weight_dims.insert(weight_dims.end(),
                                        input_dims.begin() + 1,
                                        input_dims.end());
                 }
-                auto weight_memory = array_to_memory(weight_arr, weight_dims,
-                                                     weight_format, engine);
-                temp_memory_list.push_back(weight_memory);
 
-                auto bias_arr = input_list.at(2);
-                auto bias_memory =
-                  array_to_memory(bias_arr, mkldnn::memory::format::x, engine);
-                temp_memory_list.push_back(bias_memory);
-
-                auto bias_dims = input_list.at(2).dims();
-                int output_size = weight_arr.dims()[0];
-                if(output_size != bias_dims[0]) {
+                memory_cache& bias_memory_cache = input_memory_cache_list.at(2);
+                auto bias_dims = bias_memory_cache.dims();
+                int output_size = weight_dims.at(0);
+                if(output_size != bias_dims.at(0)) {
                     throw failed_to_configure_operator(
                       node.op_type, node.output_name_list.at(0),
                       "dims[0] of input C must be equal to dims[0] of "
                       "input B: "
                       "broadcast is not supported yet");
                 }
-                mkldnn::memory::dims output_dims{input_dims[0], output_size};
 
-                auto const& output_name = node.output_name_list.at(0);
-
-                auto gemm_input_md = mkldnn::memory::desc(
-                  {input_dims}, mkldnn::memory::data_type::f32,
-                  mkldnn::memory::format::any);
+                auto const& output_memory = output_memory_list.at(0);
+                auto output_dims = extract_dims(output_memory);
+                assert(output_dims.at(0) == input_dims.at(0) &&
+                       "invalid shape inference");
+                assert(output_dims.at(1) == output_size &&
+                       "invalid shape inference");
+                auto gemm_input_md =
+                  mkldnn::memory::desc({input_dims}, input_memory_cache.dtype(),
+                                       mkldnn::memory::format::any);
                 auto gemm_weight_md = mkldnn::memory::desc(
-                  {weight_dims}, mkldnn::memory::data_type::f32,
+                  {weight_dims}, weight_memory_cache.dtype(),
                   mkldnn::memory::format::any);
                 auto gemm_output_md = mkldnn::memory::desc(
-                  {output_dims}, mkldnn::memory::data_type::f32,
+                  {output_dims}, extract_data_type(output_memory),
                   mkldnn::memory::format::any);
+
+                auto bias_memory = get_memory(
+                  bias_memory_cache, mkldnn::memory::format::x, primitives);
 
                 mkldnn::inner_product_forward::desc gemm_desc(
                   mkldnn::prop_kind::forward_inference, gemm_input_md,
@@ -111,71 +103,56 @@ namespace menoh_impl {
                 auto gemm_pd = mkldnn::inner_product_forward::primitive_desc(
                   gemm_desc, engine);
 
-                auto gemm_input_memory = input_memory;
-                if(mkldnn::memory::primitive_desc(
-                     gemm_pd.src_primitive_desc()) !=
-                   input_memory.get_primitive_desc()) {
-                    gemm_input_memory =
-                      mkldnn::memory(gemm_pd.src_primitive_desc());
-                    temp_memory_list.push_back(gemm_input_memory);
-                    primitives.push_back(
-                      mkldnn::reorder(input_memory, gemm_input_memory));
-                }
+                auto input_memory = get_memory(
+                  input_memory_cache,
+                  extract_format(gemm_pd.src_primitive_desc()), primitives);
+                auto weight_memory = get_memory(
+                  weight_memory_cache, weight_dims,
+                  extract_format(gemm_pd.weights_primitive_desc()), primitives);
 
-                auto gemm_weight_memory = weight_memory;
-                if(mkldnn::memory::primitive_desc(
-                     gemm_pd.weights_primitive_desc()) !=
-                   weight_memory.get_primitive_desc()) {
-                    gemm_weight_memory =
-                      mkldnn::memory(gemm_pd.weights_primitive_desc());
-                    temp_memory_list.push_back(gemm_weight_memory);
-                    primitives.push_back(
-                      mkldnn::reorder(weight_memory, gemm_weight_memory));
-                }
-
-                auto output_format = mkldnn::memory::format::nc;
-                std::vector<std::pair<std::string, array>>
-                  output_name_and_arr_list;
-                menoh_impl::optional<mkldnn::memory> output_memory_opt;
-                auto found = required_output_table.find(output_name);
-                if(found != required_output_table.end()) {
-                    std::string name;
-                    array output_array;
-                    std::tie(name, output_array) = *found;
-                    output_memory_opt =
-                      array_to_memory(output_array, output_format, engine);
-                }
-
-                auto output_pd = gemm_pd.dst_primitive_desc();
-                auto op_output_memory =
-                  output_memory_opt.value_or(mkldnn::memory(output_pd));
-                if(output_memory_opt &&
-                   mkldnn::memory::primitive_desc(output_pd) !=
-                     output_memory_opt->get_primitive_desc()) {
-                    op_output_memory = mkldnn::memory(output_pd);
-                    temp_memory_list.push_back(*output_memory_opt);
+                memory_cache output_memory_cache;
+                optional<mkldnn::memory> op_output_memory;
+                if(extract_format(output_memory) ==
+                     mkldnn::memory::format::any ||
+                   extract_format(output_memory) ==
+                     extract_format(gemm_pd.dst_primitive_desc())) {
+                    op_output_memory = mkldnn::memory(
+                      {{{extract_dims(output_memory)},
+                        extract_data_type(output_memory),
+                        extract_format(gemm_pd.dst_primitive_desc())},
+                       engine},
+                      output_memory.get_data_handle());
+                    output_memory_cache.add_cached_memory(*op_output_memory);
+                } else {
+                    op_output_memory = mkldnn::memory(
+                      {{{extract_dims(output_memory)},
+                        extract_data_type(output_memory),
+                        extract_format(gemm_pd.dst_primitive_desc())},
+                       engine});
+                    output_memory_cache.add_cached_memory(*op_output_memory);
+                    output_memory_cache.add_cached_memory(output_memory);
                 }
 
                 primitives.push_back(mkldnn::inner_product_forward(
-                  gemm_pd, gemm_input_memory, gemm_weight_memory, bias_memory,
-                  op_output_memory));
+                  gemm_pd, input_memory, weight_memory, bias_memory,
+                  *op_output_memory));
 
-                if(output_memory_opt &&
-                   op_output_memory != *output_memory_opt) {
+                if(extract_format(output_memory) !=
+                     mkldnn::memory::format::any &&
+                   extract_format(output_memory) !=
+                     extract_format(gemm_pd.dst_primitive_desc())) {
                     primitives.push_back(
-                      mkldnn::reorder(op_output_memory, *output_memory_opt));
+                      mkldnn::reorder(*op_output_memory, output_memory));
                 }
 
-                std::vector<std::pair<std::string, mkldnn::memory>>
-                  output_memory_list;
-                output_memory_list.emplace_back(output_name, op_output_memory);
-
-                return std::make_tuple(primitives, output_memory_list,
-                                       temp_memory_list);
+                std::vector<std::pair<std::string, memory_cache>>
+                  output_memory_cache_list({std::make_pair(
+                    node.output_name_list.at(0), output_memory_cache)});
+                return std::make_tuple(primitives, output_memory_cache_list);
             }
 
         } // namespace mkldnn_backend
-    } // namespace mkldnn_with_generic_fallback_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
 } // namespace menoh_impl
 
 #endif // MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_MKLDNN_OPERATOR_GEMM_HPP

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/output_management.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/output_management.hpp
@@ -1,0 +1,65 @@
+#ifndef MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_MKLDNN_OPERATOR_OUTPUT_MANAGEMENT_HPP
+#define MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_MKLDNN_OPERATOR_OUTPUT_MANAGEMENT_HPP
+
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/formatted_array.hpp>
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp>
+
+#include <mkldnn.hpp>
+
+namespace menoh_impl {
+    namespace mkldnn_with_generic_fallback_backend {
+        namespace mkldnn_backend {
+
+            template <typename PrimitiveGen>
+            inline std::tuple<memory_cache, std::vector<mkldnn::primitive>>
+            manage_output(
+              formatted_array const& output_formatted_array,
+              mkldnn::memory::primitive_desc const& output_memory_pd,
+              mkldnn::engine const& engine, PrimitiveGen pg) {
+                std::vector<mkldnn::primitive> primitives;
+                memory_cache output_memory_cache;
+
+                auto op_output_format = extract_format(output_memory_pd);
+                bool is_reorder_needed =
+                  !is_format_any(output_formatted_array) &&
+                  output_formatted_array.format() != op_output_format;
+                auto op_output_memory =
+                  is_reorder_needed
+                    ? mkldnn::memory(
+                        output_memory_pd) // this line allocates memory
+                    : output_formatted_array.make_memory(op_output_format,
+                                                         engine);
+                output_memory_cache.add_cached_memory(op_output_memory);
+
+                primitives.push_back(pg(op_output_memory));
+
+                if(is_reorder_needed) {
+                    auto output_memory =
+                      make_memory(output_formatted_array, engine);
+                    output_memory_cache.add_cached_memory(output_memory);
+                    primitives.push_back(
+                      mkldnn::reorder(op_output_memory, output_memory));
+                }
+                return std::make_tuple(output_memory_cache, primitives);
+            }
+
+            template <typename PrimitiveGen>
+            inline memory_cache manage_output(
+              formatted_array const& output_formatted_array,
+              mkldnn::memory::primitive_desc const& output_memory_pd,
+              mkldnn::engine const& engine,
+              std::vector<mkldnn::primitive>& primitives, PrimitiveGen pg) {
+                memory_cache output_memory_cache;
+                std::vector<mkldnn::primitive> temp_primitives;
+                std::tie(output_memory_cache, temp_primitives) = manage_output(
+                  output_formatted_array, output_memory_pd, engine, pg);
+                primitives.insert(primitives.end(), temp_primitives.begin(),
+                                  temp_primitives.end());
+                return output_memory_cache;
+            }
+
+        } // namespace mkldnn_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
+} // namespace menoh_impl
+
+#endif // MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_MKLDNN_OPERATOR_OUTPUT_MANAGEMENT_HPP

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/output_management.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/operator/output_management.hpp
@@ -17,7 +17,6 @@ namespace menoh_impl {
               mkldnn::memory::primitive_desc const& output_memory_pd,
               mkldnn::engine const& engine, PrimitiveGen pg) {
                 std::vector<mkldnn::primitive> primitives;
-                memory_cache output_memory_cache;
 
                 auto op_output_format = extract_format(output_memory_pd);
                 bool is_reorder_needed =
@@ -29,7 +28,7 @@ namespace menoh_impl {
                         output_memory_pd) // this line allocates memory
                     : output_formatted_array.make_memory(op_output_format,
                                                          engine);
-                output_memory_cache.add_cached_memory(op_output_memory);
+                memory_cache output_memory_cache(op_output_memory);
 
                 primitives.push_back(pg(op_output_memory));
 

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/procedure_factory.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/procedure_factory.hpp
@@ -1,0 +1,43 @@
+#ifndef MENOH_IMPL_MKLDNN_WITH_FALLBACK_BACKEND_BACKEND_MKLDNN_MKLDNN_PROCEDURE_FACTORY_HPP
+#define MENOH_IMPL_MKLDNN_WITH_FALLBACK_BACKEND_BACKEND_MKLDNN_MKLDNN_PROCEDURE_FACTORY_HPP
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp>
+#include <mkldnn.hpp>
+
+#define MENOH_MKLDNN_CONTEXT_PROCEDURE_FACTORY(factory_name)           \
+    factory_name(                                                      \
+      node const& node,                                                \
+      std::vector<std::reference_wrapper<memory_cache>> const&         \
+        input_memory_cache_list,                                       \
+      std::vector<formatted_array> const& output_formatted_array_list, \
+      mkldnn::engine const& engine)
+
+namespace menoh_impl {
+    namespace mkldnn_with_generic_fallback_backend {
+        namespace mkldnn_backend {
+
+            struct procedure_factory_return_type {
+                std::vector<mkldnn::primitive> primitives;
+                std::vector<memory_cache> output_memory_cache_list;
+                std::vector<std::pair<std::string, memory_cache>>
+                  named_temp_memory_cache_list;
+            };
+
+            using procedure_factory =
+              std::function<procedure_factory_return_type(
+                node const&,
+                std::vector<std::reference_wrapper<
+                  memory_cache>> const&, // input_memory_cache_list
+                std::vector<
+                  formatted_array> const&, // output_formatted_array_list
+                mkldnn::engine const&      // engine
+                )>;
+
+        } // namespace mkldnn_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
+} // namespace menoh_impl
+#endif // MENOH_IMPL_MKLDNN_WITH_FALLBACK_BACKEND_BACKEND_MKLDNN_MKLDNN_PROCEDURE_FACTORY_HPP

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/procedure_factory.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/procedure_factory.hpp
@@ -8,13 +8,15 @@
 #include <menoh/mkldnn_with_generic_fallback/backend/mkldnn/memory_cache.hpp>
 #include <mkldnn.hpp>
 
-#define MENOH_MKLDNN_CONTEXT_PROCEDURE_FACTORY(factory_name)           \
-    factory_name(                                                      \
-      node const& node,                                                \
-      std::vector<std::reference_wrapper<memory_cache>> const&         \
-        input_memory_cache_list,                                       \
-      std::vector<formatted_array> const& output_formatted_array_list, \
-      mkldnn::engine const& engine)
+#define MENOH_MKLDNN_CONTEXT_PROCEDURE_FACTORY_PARAMETER_LIST          \
+    node const &node,                                                  \
+      std::vector<std::reference_wrapper<memory_cache>> const          \
+        &input_memory_cache_list,                                      \
+      std::vector<formatted_array> const &output_formatted_array_list, \
+      mkldnn::engine const &engine
+
+#define MENOH_MKLDNN_CONTEXT_PROCEDURE_FACTORY_ARGUMENT_LIST \
+    node, input_memory_cache_list, output_formatted_array_list, engine
 
 namespace menoh_impl {
     namespace mkldnn_with_generic_fallback_backend {
@@ -29,12 +31,12 @@ namespace menoh_impl {
 
             using procedure_factory =
               std::function<procedure_factory_return_type(
-                node const&,
-                std::vector<std::reference_wrapper<
-                  memory_cache>> const&, // input_memory_cache_list
-                std::vector<
-                  formatted_array> const&, // output_formatted_array_list
-                mkldnn::engine const&      // engine
+                node const &,
+                std::vector<std::reference_wrapper<memory_cache>> const
+                  &, // input_memory_cache_list
+                std::vector<formatted_array> const
+                  &,                   // output_formatted_array_list
+                mkldnn::engine const & // engine
                 )>;
 
         } // namespace mkldnn_backend

--- a/menoh/mkldnn_with_generic_fallback/context.hpp
+++ b/menoh/mkldnn_with_generic_fallback/context.hpp
@@ -16,6 +16,8 @@ namespace menoh_impl {
 
         class context {
         public:
+            virtual ~context() = 0;
+
             optional<std::tuple<procedure, array>>
             try_to_get_variable(std::string const& name) {
                 return do_try_to_get_variable(name);
@@ -70,6 +72,7 @@ namespace menoh_impl {
             // for specialized optimization across backends
             virtual any do_take_variable_handle(std::string const& name) = 0;
         };
+        inline context::~context(){}
 
     } // namespace mkldnn_with_generic_fallback_backend
 } // namespace menoh_impl


### PR DESCRIPTION
`memory_cache` is the base building block for mkldnn backend.
It has multiple memories which may have different dims or memory format from each other but they share data contents.