### PR TITLE
Build only master branch on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 cache:
 - c:\protobuf-3.6.0-msvc
 


### PR DESCRIPTION
Prevent running build on appveyor for both branch and PR other than `master` branch.

Ref. https://help.appveyor.com/discussions/questions/1700-pushing-a-feature-branch-schedules-two-builds