### PR TITLE
fix Travis-CI osx build failure caused by conflict of oclint cask and gcc

### DIFF
--- a/.travis/macosx-x86_64/build.sh
+++ b/.travis/macosx-x86_64/build.sh
@@ -17,6 +17,7 @@ g++ --version
 
 # install prerequisites
 brew update
+brew cask uninstall oclint # oclint conflicts with gcc
 brew upgrade python
 
 export PATH=/usr/local/opt/python/libexec/bin:$PATH


### PR DESCRIPTION
The conflict caused the following error when installing numpy using homebrew.

```
==> Installing numpy dependency: gcc
==> Downloading https://homebrew.bintray.com/bottles/gcc-8.2.0.high_sierra.bottle.1.tar.gz
==> Pouring gcc-8.2.0.high_sierra.bottle.1.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink include/c++
Target /usr/local/include/c++
already exists. You may want to remove it:
  rm '/usr/local/include/c++'
To force the link and overwrite all conflicting files:
  brew link --overwrite gcc
To list all files that would be deleted:
  brew link --overwrite --dry-run gcc
Possible conflicting files are:
/usr/local/include/c++ -> /usr/local/Caskroom/oclint/0.13.1,17.4.0/oclint-0.13.1/include/c++
==> Summary
🍺  /usr/local/Cellar/gcc/8.2.0: 1,495 files, 344.8MB
```