### PR TITLE
appveyor: specify python executable explicitly for MINGW build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ build_script:
     )
   )
 - if [%TARGET%]==[mingw] (
-    cmake -G "MSYS Makefiles" -DENABLE_TEST=ON %STATIC_OPTION% -DCMAKE_INSTALL_PREFIX=/mingw64 .. &&
+    cmake -G "MSYS Makefiles" -DENABLE_TEST=ON %STATIC_OPTION% -DCMAKE_INSTALL_PREFIX=/mingw64 -DPYTHON_EXECUTABLE=/mingw64/bin/python3 .. &&
     make
   ) else (
     cmake -G "Visual Studio 14 Win64" -DENABLE_TEST=OFF -DENABLE_BENCHMARK=OFF -DENABLE_EXAMPLE=OFF -DCMAKE_INSTALL_PREFIX=c:\menoh-%MENOH_REV%-msvc .. &&


### PR DESCRIPTION
For using `/mingw64/bin/python3` instead of `C:/Python27/python.exe`.