### PR TITLE
implement generic reshape

### DIFF
--- a/menoh/attribute_completion_and_shape_inference.hpp
+++ b/menoh/attribute_completion_and_shape_inference.hpp
@@ -875,6 +875,44 @@ add_variable_to_table(output(0), dtype_of(input(0)), dims_of(input(0)));
 else
 
 
+if(node.op_type == "Reshape") {
+    
+    
+    
+    {
+        
+        
+auto found = std::find_if(model_data.parameter_name_and_array_list.begin(),
+                          model_data.parameter_name_and_array_list.end(),
+                          [shape_name=node.input_name_list.at(1)](
+                            auto const& p){ return p.first == shape_name; });
+assert(found != model_data.parameter_name_and_array_list.end());
+auto shape = found->second;
+std::vector<int> new_dims(menoh_impl::begin<dtype_t::int64>(shape),
+                          menoh_impl::end<dtype_t::int64>(shape));
+for(unsigned int i = 0; i < new_dims.size(); ++i) {
+    if(new_dims.at(i) == 0) {
+        assert(i < ndims_of(input(0)));
+        new_dims.at(i) = dims_of(input(0)).at(i);
+    }
+    auto found =
+      std::find(new_dims.begin(), new_dims.end(), -1);
+    if(found != new_dims.end()) {
+        auto other_size =
+          -std::accumulate(new_dims.begin(), new_dims.end(),
+                           1, std::multiplies<>());
+        auto total_size = calc_total_size(dims_of(input(0)));
+        assert(total_size % other_size == 0);
+        *found = total_size / other_size;
+    }
+}
+add_variable_to_table(output(0), dtype_of(input(0)), new_dims);
+
+    }
+}
+else
+
+
 if(node.op_type == "Sigmoid") {
     
     

--- a/menoh/mkldnn_with_generic_fallback/backend/generic/generic_context.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/generic/generic_context.cpp
@@ -7,6 +7,7 @@ namespace menoh_impl {
 
             generic_context::generic_context() : context() {
                 procedure_factory_table_.emplace("Relu", make_relu);
+                procedure_factory_table_.emplace("Reshape", make_reshape);
                 procedure_factory_table_.emplace("Mul", make_mul);
                 procedure_factory_table_.emplace("Sigmoid", make_sigmoid);
                 procedure_factory_table_.emplace("Transpose", make_transpose);

--- a/menoh/mkldnn_with_generic_fallback/backend/generic/operator.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/generic/operator.hpp
@@ -1,8 +1,9 @@
 #ifndef MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_GENERIC_OPERATOR_HPP
 #define MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_GENERIC_OPERATOR_HPP
 
-#include <menoh/mkldnn_with_generic_fallback/backend/generic/operator/relu.hpp>
 #include <menoh/mkldnn_with_generic_fallback/backend/generic/operator/mul.hpp>
+#include <menoh/mkldnn_with_generic_fallback/backend/generic/operator/relu.hpp>
+#include <menoh/mkldnn_with_generic_fallback/backend/generic/operator/reshape.hpp>
 #include <menoh/mkldnn_with_generic_fallback/backend/generic/operator/sigmoid.hpp>
 #include <menoh/mkldnn_with_generic_fallback/backend/generic/operator/transpose.hpp>
 

--- a/menoh/mkldnn_with_generic_fallback/backend/generic/operator/reshape.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/generic/operator/reshape.hpp
@@ -1,0 +1,32 @@
+#ifndef MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_GENERIC_OPERATOR_RESHAPE_HPP
+#define MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_GENERIC_OPERATOR_RESHAPE_HPP
+
+#include <menoh/array.hpp>
+#include <menoh/graph.hpp> // for dimension_mismatch error
+#include <menoh/mkldnn_with_generic_fallback/procedure.hpp>
+
+namespace menoh_impl {
+    namespace mkldnn_with_generic_fallback_backend {
+        namespace generic_backend {
+            inline procedure
+            make_reshape(node const& node, std::vector<array> const& input_list,
+                         std::vector<array> const& output_list) {
+                assert(input_list.size() == 2);
+                assert(output_list.size() == 1);
+
+                auto procedure = [data = input_list.at(0),
+                                  output = output_list.at(0)]() {
+                    assert(total_size(data) == total_size(output));
+                    std::copy(begin<dtype_t::float32>(data),
+                              end<dtype_t::float32>(data),
+                              begin<dtype_t::float32>(output));
+                };
+
+                return procedure;
+            }
+
+        } // namespace generic_backend
+    }     // namespace mkldnn_with_generic_fallback_backend
+} // namespace menoh_impl
+
+#endif // MENOH_IMPL_MKLDNN_WITH_GENERIC_FALLBACK_BACKEND_BACKEND_GENERIC_OPERATOR_RESHAPE_HPP

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.cpp
@@ -79,6 +79,23 @@ namespace menoh_impl {
                           input_memory_cache_list;
                         for(auto const& input_name : node.input_name_list) {
                             do {
+                                // search in self variable table
+                                {
+                                    auto found =
+                                      variable_memory_cache_table_.find(
+                                        input_name);
+                                    if(found !=
+                                       variable_memory_cache_table_.end()) {
+                                        *logger << input_name
+                                                << " is found from self "
+                                                   "variable table"
+                                                << std::endl;
+                                        input_memory_cache_list.push_back(
+                                          found->second);
+                                        break;
+                                    }
+                                }
+
                                 // search in common parameter table
                                 {
                                     auto found =
@@ -98,23 +115,6 @@ namespace menoh_impl {
                                           "already same named variable exist");
                                         input_memory_cache_list.push_back(
                                           std::ref(result_pair.first->second));
-                                        break;
-                                    }
-                                }
-
-                                // search in self variable table
-                                {
-                                    auto found =
-                                      variable_memory_cache_table_.find(
-                                        input_name);
-                                    if(found !=
-                                       variable_memory_cache_table_.end()) {
-                                        *logger << input_name
-                                                << " is found from self "
-                                                   "variable table"
-                                                << std::endl;
-                                        input_memory_cache_list.push_back(
-                                          found->second);
                                         break;
                                     }
                                 }

--- a/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.hpp
+++ b/menoh/mkldnn_with_generic_fallback/backend/mkldnn/mkldnn_context.hpp
@@ -40,6 +40,10 @@ namespace menoh_impl {
                                  ndims_to_data_memory_format(
                                    variable_memory_cache.dims().size()),
                                  primitives);
+                    assert(extract_format(variable_memory) ==
+                             mkldnn::memory::format::nchw ||
+                           extract_format(variable_memory) ==
+                             mkldnn::memory::format::nc);
                     procedure copy_proc =
                       primitives.empty()
                         ? procedure(nullptr)

--- a/menoh/onnx.cpp
+++ b/menoh/onnx.cpp
@@ -14,7 +14,6 @@
 #include <onnx/onnx.pb.h>
 
 #include <menoh/array.hpp>
-#include <menoh/dtype.hpp>
 #include <menoh/exception.hpp>
 #include <menoh/graph.hpp>
 #include <menoh/model_data.hpp>

--- a/test/operator.cpp
+++ b/test/operator.cpp
@@ -52,16 +52,30 @@ namespace {
         auto total_size =
           std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
         assert(tensor.has_raw_data());
-        assert(
-          tensor.raw_data().length() ==
-          static_cast<decltype(tensor.raw_data().length())>(total_size * 4));
+        if(tensor.data_type() == onnx::TensorProto_DataType_FLOAT) {
+            assert(tensor.raw_data().length() ==
+                   static_cast<decltype(tensor.raw_data().length())>(
+                     total_size * 4));
 
-        auto data = std::make_unique<char[]>(total_size * 4);
-        std::copy(tensor.raw_data().begin(), tensor.raw_data().end(),
-                  data.get());
-        // TODO other dtype
-        return named_array_data{tensor.name(), menoh::dtype_t::float_,
-                                std::move(dims), std::move(data)};
+            auto data = std::make_unique<char[]>(total_size * 4);
+            std::copy(tensor.raw_data().begin(), tensor.raw_data().end(),
+                      data.get());
+            // TODO other dtype
+            return named_array_data{tensor.name(), menoh::dtype_t::float32,
+                                    std::move(dims), std::move(data)};
+        }
+        if(tensor.data_type() == onnx::TensorProto_DataType_INT64) {
+            assert(tensor.raw_data().length() ==
+                   static_cast<decltype(tensor.raw_data().length())>(
+                     total_size * 8));
+
+            auto data = std::make_unique<char[]>(total_size * 8);
+            std::copy(tensor.raw_data().begin(), tensor.raw_data().end(),
+                      data.get());
+            // TODO other dtype
+            return named_array_data{tensor.name(), menoh::dtype_t::int64,
+                                    std::move(dims), std::move(data)};
+        }
     }
 
     class OperatorTest : public ::testing::Test {
@@ -210,8 +224,8 @@ namespace {
     TEST_OP(mkldnn, test_globalaveragepool_precomputed, eps);
     TEST_OP(mkldnn, test_globalmaxpool, eps);
     TEST_OP(mkldnn, test_globalmaxpool_precomputed, eps);
-    //TEST_OP(mkldnn, test_globalaveragepool, eps);
-    //TEST_OP(mkldnn, test_globalmaxpool, eps);
+    // TEST_OP(mkldnn, test_globalaveragepool, eps);
+    // TEST_OP(mkldnn, test_globalmaxpool, eps);
     TEST_OP(mkldnn, test_maxpool_2d_default, eps);
     TEST_OP_SQUASH_DIMS(mkldnn, test_softmax_axis_1, eps);
     // TEST_OP_SQUASH_DIMS(mkldnn, test_sum_one_input, eps);
@@ -277,6 +291,13 @@ namespace {
     //TEST_OP(mkldnn_with_generic_fallback, test_maxpool_3d_default, eps);
     //TEST_OP(mkldnn_with_generic_fallback, test_maxpool_with_argmax_2d_precomputed_pads, eps);
     //TEST_OP(mkldnn_with_generic_fallback, test_maxpool_with_argmax_2d_precomputed_strides, eps);
+
+    // Reshape
+    //TEST_OP(mkldnn_with_generic_fallback, test_reshape_extended_dims, eps);
+    //TEST_OP(mkldnn_with_generic_fallback, test_reshape_negative_dim, eps);
+    //TEST_OP(mkldnn_with_generic_fallback, test_reshape_one_dim, eps);
+    //TEST_OP(mkldnn_with_generic_fallback, test_reshape_reduced_dims, eps);
+    //TEST_OP(mkldnn_with_generic_fallback, test_reshape_reordered_dims, eps);
 
     // Softmax
     //TEST_OP(mkldnn_with_generic_fallback, test_softmax_axis_0, eps);


### PR DESCRIPTION
Add Reshape operator to generic context.
To make it enable, remove trim_reshape(node_list) line in onnx.cpp.
It is kept for backward compatibility. It will be eliminated by future PR.
Thisi PR depends on #168