### PR TITLE
fix JSON parse error when passing empty string as backend_config for mkldnn_with_generic_fallback backend

### DIFF
--- a/menoh/model_core_factory.cpp
+++ b/menoh/model_core_factory.cpp
@@ -20,7 +20,7 @@ namespace menoh_impl {
               mkldnn_backend::make_model_core(
                 input_table, required_output_table, model_data, config));
         } else if(backend_name == "mkldnn_with_generic_fallback") {
-            auto conf = nlohmann::json::parse(config);
+            auto conf = nlohmann::json::parse(config.empty() ? "{}" : config);
             conf.merge_patch(
               R"({"backends":[{"type":"mkldnn"}, {"type":"generic"}]})");
             return std::make_unique<composite_backend::model_core>(


### PR DESCRIPTION
`menoh_build_model(model_builder, model_data, "mkldnn", "", &model)` worked. So I expect `menoh_build_model(model_builder, model_data, "mkldnn_with_generic_fallback", "", &model)` also works.