### PR TITLE
bump minor version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.1)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(MENOH_MAJOR_VERSION 1)
-set(MENOH_MINOR_VERSION 1)
-set(MENOH_PATCH_VERSION 1)
+set(MENOH_MINOR_VERSION 2)
+set(MENOH_PATCH_VERSION 0)
 
 # Options
 option(USE_OLD_GLIBCXX_ABI "Generate binaries for the old libstdc++ ABI" OFF)


### PR DESCRIPTION
Because `menoh_dtype_size()` and some `menoh_dtype_*` constants have been introduced after the 1.1.1 release.