### PR TITLE
replace CV_LOAD_IMAGE_COLOR -> cv::IMREAD_COLOR

### DIFF
--- a/example/general_cnn_example_in_cpp.cpp
+++ b/example/general_cnn_example_in_cpp.cpp
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
     auto onnx_model_path = a.get<std::string>("model");
 
     cv::Mat image_mat =
-      cv::imread(input_image_path.c_str(), CV_LOAD_IMAGE_COLOR);
+      cv::imread(input_image_path.c_str(), cv::IMREAD_COLOR);
     if(!image_mat.data) {
         throw std::runtime_error("Invalid input image path: " +
                                  input_image_path);

--- a/example/vgg16_example_in_cpp.cpp
+++ b/example/vgg16_example_in_cpp.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
     auto synset_words_path = a.get<std::string>("synset_words");
 
     cv::Mat image_mat =
-      cv::imread(input_image_path.c_str(), CV_LOAD_IMAGE_COLOR);
+      cv::imread(input_image_path.c_str(), cv::IMREAD_COLOR);
     if(!image_mat.data) {
         throw std::runtime_error("Invalid input image path: " +
                                  input_image_path);


### PR DESCRIPTION
`CV_LOAD_IMAGE_COLOR` is a constant in old C interface.
OpenCV4 no longer define it by default.