### PR TITLE
Remove deprecated API for MKL-DNN backend

### DIFF
--- a/menoh/composite_backend/backend/mkldnn/operator/batch_norm.hpp
+++ b/menoh/composite_backend/backend/mkldnn/operator/batch_norm.hpp
@@ -88,8 +88,7 @@ namespace menoh_impl {
                 mkldnn::batch_normalization_forward::desc batch_norm_desc(
                   mkldnn::prop_kind::forward_inference,
                   input_memory.get_primitive_desc().desc(), epsilon,
-                  mkldnn::use_global_stats | mkldnn::use_scale_shift |
-                    mkldnn::omit_stats);
+                  mkldnn::use_global_stats | mkldnn::use_scale_shift);
                 mkldnn::batch_normalization_forward::primitive_desc
                   batch_norm_pd(batch_norm_desc, engine);
 


### PR DESCRIPTION
The method [`omit_stats` is deprecated and removed](https://github.com/intel/mkl-dnn/commit/b7ab4a7b5985f98eb593cde9bdb7cee78f86bfa2#diff-d8a713d0b47b370945354e3236daac73L66) on MKL-DNN v0.17.
So this PR removes the dependency for this method.