### PR TITLE
fixed file path in example/vgg16_example_in_c.c

### DIFF
--- a/example/vgg16_example_in_c.c
+++ b/example/vgg16_example_in_c.c
@@ -24,7 +24,7 @@ int main() {
 
     menoh_model_data_handle model_data;
     ERROR_CHECK(
-      menoh_make_model_data_from_onnx("../data/VGG16.onnx", &model_data));
+      menoh_make_model_data_from_onnx("../data/vgg16.onnx", &model_data));
 
     menoh_variable_profile_table_builder_handle vpt_builder;
     ERROR_CHECK(menoh_make_variable_profile_table_builder(&vpt_builder));


### PR DESCRIPTION
The file name downloaded with scripts/retrieve_data.py seems to be lower case.  
In case sensitive environment, it raise error as following.

```
menoh invalid filename error: ../data/VGG16.onnx
```

By this modification, that error will be solved I think.