### PR TITLE
add get_dims() API

### DIFF
--- a/example/vgg16_example_in_c.c
+++ b/example/vgg16_example_in_c.c
@@ -44,6 +44,15 @@ int main() {
     ERROR_CHECK(menoh_build_variable_profile_table(vpt_builder, model_data,
                                                    &variable_profile_table));
 
+    int32_t softmax_out_dims_size;
+    const int32_t* softmax_out_dims;
+    ERROR_CHECK(menoh_variable_profile_table_get_dims(
+      variable_profile_table, softmax_out_name, &softmax_out_dims_size,
+      &softmax_out_dims));
+    assert(softmax_out_dims_size == 2);
+    assert(softmax_out_dims[0]== 1);
+    assert(softmax_out_dims[1] == 1000);
+
     /*
     int32_t softmax_out_dims[2];
     ERROR_CHECK(menoh_variable_profile_table_get_dims_at(
@@ -52,14 +61,6 @@ int main() {
       variable_profile_table, softmax_out_name, 1, &softmax_out_dims[1]));
     */
 
-    int32_t softmax_out_dims_size;
-    const int32_t* softmax_out_dims;
-    ERROR_CHECK(menoh_variable_profile_table_get_dims(
-      variable_profile_table, softmax_out_name, &softmax_out_dims_size,
-      &softmax_out_dims));
-    assert(softmax_out_dims_size == 1);
-    assert(softmax_out_dims[0]== 2);
-    assert(softmax_out_dims[1] == 1000);
 
     ERROR_CHECK(menoh_model_data_optimize(model_data, variable_profile_table));
 

--- a/example/vgg16_example_in_c.c
+++ b/example/vgg16_example_in_c.c
@@ -79,11 +79,11 @@ int main() {
       model_data); // you can delete model_data after model building
 
     float* fc6_output_buff;
-    ERROR_CHECK(menoh_model_get_variable_buffer_handle(model, fc6_out_name,
-                                              (void**)&fc6_output_buff));
+    ERROR_CHECK(menoh_model_get_variable_buffer_handle(
+      model, fc6_out_name, (void**)&fc6_output_buff));
     float* softmax_output_buff;
-    ERROR_CHECK(menoh_model_get_variable_buffer_handle(model, softmax_out_name,
-                                              (void**)&softmax_output_buff));
+    ERROR_CHECK(menoh_model_get_variable_buffer_handle(
+      model, softmax_out_name, (void**)&softmax_output_buff));
 
     // initialie input_buf here
     for(int i = 0; i < 1 * 3 * 224 * 224; ++i) {

--- a/example/vgg16_example_in_c.c
+++ b/example/vgg16_example_in_c.c
@@ -53,6 +53,7 @@ int main() {
     assert(softmax_out_dims[0]== 1);
     assert(softmax_out_dims[1] == 1000);
 
+    /* Another way to take dims of variables */
     /*
     int32_t softmax_out_dims[2];
     ERROR_CHECK(menoh_variable_profile_table_get_dims_at(

--- a/include/menoh/menoh.h
+++ b/include/menoh/menoh.h
@@ -101,7 +101,8 @@ MENOH_API const char* menoh_get_last_error_message();
  */
 /*! \breaf Element size of given menoh_dtype.
  */
-menoh_error_code MENOH_API menoh_dtype_size(menoh_dtype dtype, int32_t *dst_size);
+menoh_error_code MENOH_API menoh_dtype_size(menoh_dtype dtype,
+                                            int32_t* dst_size);
 
 /*! @addtogroup model_data Model data types and operations
  * @{ */
@@ -226,7 +227,8 @@ menoh_variable_profile_table_builder_add_input_profile(
  *
  * Input profile contains name, dtype and dims (num, size). This 2D input is
  * conventional batched 1D inputs.
- * \warning This function is depreated. Please use menoh_variable_profile_table_builder_add_input_profile() instead
+ * \warning This function is depreated. Please use
+ * menoh_variable_profile_table_builder_add_input_profile() instead
  */
 MENOH_DEPRECATED_ATTRIBUTE(
   "please use menoh_variable_profile_table_builder_add_input_profile() instead")
@@ -240,7 +242,8 @@ menoh_variable_profile_table_builder_add_input_profile_dims_2(
  * Input profile contains name, dtype and dims (num, channel, height, width).
  * This 4D input is conventional batched image inputs. Image input is
  * 3D(channel, height, width).
- * \warning This function is depreated. Please use menoh_variable_profile_table_builder_add_input_profile() instead
+ * \warning This function is depreated. Please use
+ * menoh_variable_profile_table_builder_add_input_profile() instead
  */
 MENOH_DEPRECATED_ATTRIBUTE(
   "please use menoh_variable_profile_table_builder_add_input_profile() instead")
@@ -262,7 +265,8 @@ menoh_error_code MENOH_API menoh_variable_profile_table_builder_add_output_name(
  *
  * Output profile contains name and dtype. Its dims are calculated automatically
  * when calling of menoh_build_variable_profile_table.
- * \warning This function is depreated. Please use menoh_variable_profile_table_builder_add_output_name() instead
+ * \warning This function is depreated. Please use
+ * menoh_variable_profile_table_builder_add_output_name() instead
  */
 MENOH_DEPRECATED_ATTRIBUTE(
   "please use menoh_variable_profile_table_builder_add_output_name() instead. "
@@ -284,9 +288,11 @@ typedef struct menoh_variable_profile_table*
 
 /*! \brief Factory function for variable_profile_table
  *
- * \note this function throws menoh_input_not_found_error when no nodes have given input name.
- * \note this function throws menoh_output_not_found_error when no nodes have given output name.
- * \note this function throws menoh_variable_not_found_error when needed variable for model execution does not exist.
+ * \note this function throws menoh_input_not_found_error when no nodes have
+ * given input name. \note this function throws menoh_output_not_found_error
+ * when no nodes have given output name. \note this function throws
+ * menoh_variable_not_found_error when needed variable for model execution does
+ * not exist.
  */
 menoh_error_code MENOH_API menoh_build_variable_profile_table(
   const menoh_variable_profile_table_builder_handle builder,
@@ -327,6 +333,15 @@ menoh_error_code MENOH_API menoh_variable_profile_table_get_dims_size(
 menoh_error_code MENOH_API menoh_variable_profile_table_get_dims_at(
   const menoh_variable_profile_table_handle variable_profile_table,
   const char* variable_name, int32_t index, int32_t* dst_size);
+
+/*! \brief Accessor function for variable_profile_table
+ *
+ * Select variable name, then get its dims size and dims array
+ *
+ */
+menoh_error_code MENOH_API menoh_variable_profile_table_get_dims(
+  const menoh_variable_profile_table_handle variable_profile_table,
+  const char* variable_name, int32_t* dst_size, const int32_t** dims);
 
 /** @} */
 
@@ -437,6 +452,15 @@ menoh_error_code MENOH_API menoh_model_get_variable_dims_size(
 menoh_error_code MENOH_API menoh_model_get_variable_dims_at(
   const menoh_model_handle model, const char* variable_name, int32_t index,
   int32_t* dst_size);
+
+/*! \brief Get dims of target variable
+ *
+ * \sa
+ * menoh_variable_profile_table_get_dims()
+ */
+menoh_error_code MENOH_API menoh_model_get_variable_dims(
+  const menoh_model_handle model, const char* variable_name, int32_t* dst_size,
+  const int32_t** dims);
 
 /*! \brief Run model inference
  *

--- a/menoh/menoh.cpp
+++ b/menoh/menoh.cpp
@@ -93,24 +93,26 @@ menoh_error_code check_error(Func func) {
  * dtype
  */
 
-menoh_error_code MENOH_API menoh_dtype_size(menoh_dtype dtype, int32_t *dst_size) {
-    switch (dtype) {
-#define MENOH_DTYPE_SIZE_CASE(dtype) \
-    case dtype: \
-        *dst_size = menoh_impl::size_in_bytes<static_cast<menoh_impl::dtype_t>(dtype)>; \
+menoh_error_code MENOH_API menoh_dtype_size(menoh_dtype dtype,
+                                            int32_t* dst_size) {
+    switch(dtype) {
+#define MENOH_DTYPE_SIZE_CASE(dtype)                                          \
+    case dtype:                                                               \
+        *dst_size =                                                           \
+          menoh_impl::size_in_bytes<static_cast<menoh_impl::dtype_t>(dtype)>; \
         break;
-    MENOH_DTYPE_SIZE_CASE(menoh_dtype_float)
-    MENOH_DTYPE_SIZE_CASE(menoh_dtype_float16)
-    MENOH_DTYPE_SIZE_CASE(menoh_dtype_float64)
-    MENOH_DTYPE_SIZE_CASE(menoh_dtype_int8)
-    MENOH_DTYPE_SIZE_CASE(menoh_dtype_int16)
-    MENOH_DTYPE_SIZE_CASE(menoh_dtype_int32)
-    MENOH_DTYPE_SIZE_CASE(menoh_dtype_int64)
+        MENOH_DTYPE_SIZE_CASE(menoh_dtype_float)
+        MENOH_DTYPE_SIZE_CASE(menoh_dtype_float16)
+        MENOH_DTYPE_SIZE_CASE(menoh_dtype_float64)
+        MENOH_DTYPE_SIZE_CASE(menoh_dtype_int8)
+        MENOH_DTYPE_SIZE_CASE(menoh_dtype_int16)
+        MENOH_DTYPE_SIZE_CASE(menoh_dtype_int32)
+        MENOH_DTYPE_SIZE_CASE(menoh_dtype_int64)
 #undef MENOH_DTYPE_SIZE_CASE
-    default:
-        std::string msg("unknown dtype: " + std::to_string(dtype));
-        menoh_impl::set_last_error_message(msg.c_str());
-        return menoh_error_code_invalid_dtype;
+        default:
+            std::string msg("unknown dtype: " + std::to_string(dtype));
+            menoh_impl::set_last_error_message(msg.c_str());
+            return menoh_error_code_invalid_dtype;
     }
     return menoh_error_code_success;
 }

--- a/menoh/menoh.cpp
+++ b/menoh/menoh.cpp
@@ -464,6 +464,16 @@ menoh_error_code menoh_variable_profile_table_get_dims_at(
       [&](auto const& profile) { *dst_size = profile.dims().at(index); });
 }
 
+menoh_error_code menoh_variable_profile_table_get_dims(
+  const menoh_variable_profile_table_handle variable_profile_table,
+  const char* name, int32_t* dst_size, const int32_t** dims) {
+    return impl::menoh_variable_profile_table_get_variable_attribute(
+      variable_profile_table, name, [&](auto const& profile) {
+          *dst_size = profile.dims().size();
+          *dims = profile.dims().data();
+      });
+}
+
 menoh_error_code menoh_model_data_optimize(
   menoh_model_data_handle model_data,
   const menoh_variable_profile_table_handle variable_profile_table) {
@@ -653,6 +663,17 @@ menoh_model_get_variable_dims_at(const menoh_model_handle model,
     return impl::menoh_model_get_variable_variable_attribute(
       model, variable_name,
       [&](menoh_impl::array const& arr) { *dst_size = arr.dims().at(index); });
+}
+
+menoh_error_code menoh_model_get_variable_dims(const menoh_model_handle model,
+                                               const char* variable_name,
+                                               int32_t* dst_size,
+                                               const int32_t** dims) {
+    return impl::menoh_model_get_variable_variable_attribute(
+      model, variable_name, [&](menoh_impl::array const& arr) {
+          *dst_size = arr.dims().size();
+          *dims = arr.dims().data();
+      });
 }
 
 menoh_error_code menoh_model_run(menoh_model_handle model) {


### PR DESCRIPTION
This PR adds `menoh_variable_profile_table_get_dims()` and `menoh_model_get_variable_dims()`.
See #48