### PR TITLE
use the name oneDNN instead of mkl-dnn in scripts/build-mkldnn.sh

### DIFF
--- a/.travis/init-build-linux.sh
+++ b/.travis/init-build-linux.sh
@@ -64,7 +64,7 @@ function build_mkldnn() {
 function install_mkldnn() {
     docker_exec_script \
         "${PROJ_DIR}/scripts/install-mkldnn.sh" \
-            --build-dir "${WORK_DIR}/build/mkl-dnn-${MKLDNN_VERSION}/build"
+            --build-dir "${WORK_DIR}/build/oneDNN-${MKLDNN_VERSION}/build"
 }
 
 function prepare_menoh_data() {

--- a/scripts/build-mkldnn.sh
+++ b/scripts/build-mkldnn.sh
@@ -48,7 +48,7 @@ test -n "${ARG_EXTRACT_DIR}" || { echo "--extract-dir is not specified" 1>&2; ex
 # options that have default value
 test -n "${ARG_VERSION}" || readonly ARG_VERSION=0.16
 
-readonly LIBRARY_NAME=mkl-dnn-${ARG_VERSION}
+readonly LIBRARY_NAME=oneDNN-${ARG_VERSION}
 readonly SOURCE_DIR="${ARG_EXTRACT_DIR}/${LIBRARY_NAME}"
 
 test -n "${ARG_BUILD_DIR}" || readonly ARG_BUILD_DIR="${SOURCE_DIR}/build"


### PR DESCRIPTION
Because tarball downloaded from github constians `oneDNN` directory even if the tarball is for the release before the rename.