### PR TITLE
re-enable Travis-CI builds for osx by not using mkl-dnn provided by Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,12 @@ cache:
 
 matrix:
     include:
-        # osx builds were disabled, because Menoh does not yet support newer mkl-dnn (oneDNN) installed by current Homebrew.
-        # - os: osx
-        #   env: PLATFORM=macosx-x86_64
-        # - os: osx
-        #   env: PLATFORM=macosx-x86_64 LINK_STATIC=true
-        # - os: osx
-        #   env: PLATFORM=macosx-x86_64 BUILD_STATIC_LIBS=true
+        - os: osx
+          env: PLATFORM=macosx-x86_64
+        - os: osx
+          env: PLATFORM=macosx-x86_64 LINK_STATIC=true
+        - os: osx
+          env: PLATFORM=macosx-x86_64 BUILD_STATIC_LIBS=true
         - os: linux
           env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6
         - os: linux

--- a/.travis/init-build-osx.sh
+++ b/.travis/init-build-osx.sh
@@ -7,7 +7,23 @@ test -n "${BUILD_STATIC_LIBS}" || BUILD_STATIC_LIBS=false
 export WORK_DIR=${HOME}
 export PROJ_DIR=${TRAVIS_BUILD_DIR} # = ${HOME}/build/${TRAVIS_REPO_SLUG}
 
+export MKLDNN_INSTALL_DIR=/usr/local
+
 ## define shared functions for macOS (OSX) platforms
+
+function build_mkldnn() {
+    bash -ex "${PROJ_DIR}/scripts/build-mkldnn.sh" \
+        --version ${MKLDNN_VERSION} \
+        --download-dir "${WORK_DIR}/downloads" \
+        --extract-dir "${WORK_DIR}/build" \
+        --install-dir "${MKLDNN_INSTALL_DIR}" \
+        --parallel ${MAKE_JOBS}
+}
+
+function install_mkldnn() {
+    bash -ex "${PROJ_DIR}/scripts/install-mkldnn.sh" \
+        --build-dir "${WORK_DIR}/build/oneDNN-${MKLDNN_VERSION}/build"
+}
 
 function prepare_menoh_data() {
     bash -ex "${PROJ_DIR}/scripts/prepare-menoh-data.sh" \

--- a/.travis/macosx-x86_64/build.sh
+++ b/.travis/macosx-x86_64/build.sh
@@ -22,7 +22,7 @@ brew upgrade python
 export PATH=/usr/local/opt/python/libexec/bin:$PATH
 
 brew install numpy || true
-brew install opencv mkl-dnn
+brew install opencv
 
 if [ "$LINK_STATIC" != "true" ]; then brew install protobuf; fi
 
@@ -30,6 +30,10 @@ pip install --user chainer # for generating test data
 
 brew list --versions
 pip list
+
+# build and install prerequisites
+build_mkldnn
+install_mkldnn
 
 # build and test menoh
 build_menoh


### PR DESCRIPTION
In #228 I disabled osx builds on Travis-CI because Menoh does not yet support newer mkl-dnn (oneDNN) installed by current Homebrew.

This PR re-enable osx builds by not using mkl-dnn provided by Homebrew.