### PR TITLE
Use macOS Mojave (10.14) for macOS build on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,13 @@ cache:
 matrix:
     include:
         - os: osx
+          osx_image: xcode10.2
           env: PLATFORM=macosx-x86_64
         - os: osx
+          osx_image: xcode10.2
           env: PLATFORM=macosx-x86_64 LINK_STATIC=true
         - os: osx
+          osx_image: xcode10.2
           env: PLATFORM=macosx-x86_64 BUILD_STATIC_LIBS=true
         - os: linux
           env: PLATFORM=linux-x86_64 BUILDENV_IMAGE=okapies/buildenv:linux-x64-devtoolset-6


### PR DESCRIPTION
Homebrew recommends using macOS Mojave (10.14) (or higher), and I hope this fixes the build time issue on Travis-CI.